### PR TITLE
[graphics] Better font selection and no superscripts on Windows

### DIFF
--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurConsole.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurConsole.java
@@ -49,6 +49,7 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
+import org.alloytools.graphics.util.AlloyGraphics;
 import org.alloytools.util.table.Table;
 
 /**
@@ -78,7 +79,7 @@ public final class OurConsole extends JScrollPane {
     private final static AttributeSet plain               = style("Verdana", 14, false, false, false, Color.BLACK, 0);
 
     /** The style for table text. */
-    private final static AttributeSet mono                = style("Courier", 14, false, false, false, Color.BLACK, 10);
+    private final static AttributeSet mono                = style("Input Mono,DejaVu Sans Mono,Courier New,Courier", 14, false, false, false, Color.BLACK, 10);
 
     /** The style for bold text. */
     private final static AttributeSet bold                = style("Verdana", 14, true, false, false, Color.BLACK, 0);
@@ -127,6 +128,10 @@ public final class OurConsole extends JScrollPane {
      * size, boldness, color, and left indentation.
      */
     static MutableAttributeSet style(String fontName, int fontSize, boolean boldness, boolean italic, boolean strike, Color color, int leftIndent) {
+
+
+        fontName = AlloyGraphics.matchBestFontName(fontName);
+
         MutableAttributeSet s = new SimpleAttributeSet();
         StyleConstants.setFontFamily(s, fontName);
         StyleConstants.setFontSize(s, fontSize);

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.alloytools.alloy.core.AlloyCore;
 import org.alloytools.util.table.Table;
 
 import edu.mit.csail.sdg.ast.Sig;
@@ -82,6 +83,9 @@ public class TableView {
     }
 
     public static String toScriptedString(String atom, Set<String> multiple) {
+
+        if (AlloyCore.isWindows())
+            return atom;
 
         if (atom.matches(".*\\$\\d+")) {
             StringBuilder sb = new StringBuilder();

--- a/org.alloytools.alloy.core/src/main/java/org/alloytools/alloy/core/AlloyCore.java
+++ b/org.alloytools.alloy.core/src/main/java/org/alloytools/alloy/core/AlloyCore.java
@@ -1,5 +1,7 @@
 package org.alloytools.alloy.core;
 
+import java.io.File;
+
 /**
  * Class for globally accessible things.
  *
@@ -27,5 +29,10 @@ public class AlloyCore {
         } catch (Exception e) {
             // ignore, only running in debug mode
         }
+    }
+
+
+    public static boolean isWindows() {
+        return File.separatorChar == '\\';
     }
 }

--- a/org.alloytools.alloy.core/src/main/java/org/alloytools/graphics/util/AlloyGraphics.java
+++ b/org.alloytools.alloy.core/src/main/java/org/alloytools/graphics/util/AlloyGraphics.java
@@ -1,0 +1,34 @@
+package org.alloytools.graphics.util;
+
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AlloyGraphics {
+
+    private static Set<String> availableFontNames;
+
+    public static synchronized String matchBestFontName(String fontName) {
+        String[] names = fontName.trim().split("\\s*,\\s*");
+        if (availableFontNames == null) {
+            GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+            availableFontNames = new HashSet<>(Arrays.asList(ge.getAvailableFontFamilyNames()));
+        }
+        for (String name : names) {
+            if (name.startsWith("$")) {
+                name = name.substring(1);
+                Font font = Font.getFont(name);
+                if (font != null)
+                    return font.getFontName();
+            } else {
+                if (availableFontNames.contains(name))
+                    return name;
+            }
+        }
+        return names[names.length - 1];
+    }
+
+
+}


### PR DESCRIPTION
Fixes complaint that the superscripts in the atom names in the table view do not show properly on
windows.

Will now show the good old ‘$’ on windows …

(And maybe we should also do this on others …)