### PR TITLE
Add warning on save conflicts

### DIFF
--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
@@ -26,6 +26,7 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Objects;
 
 import javax.swing.AbstractAction;
@@ -92,6 +93,11 @@ public final class OurSyntaxWidget {
      * event)
      */
     private String                          filename  = "";
+
+    /**
+     * the file modification date for the file loaded. If no file is loaded (!isFile), this must be -1.
+     */
+    private long                            fileModifiedDate = -1;
 
     /**
      * Whether this JTextPane has been modified since last load/save (changes will
@@ -685,6 +691,7 @@ public final class OurSyntaxWidget {
         for (int i = 1;; i++)
             if (!bannedNames.contains(filename = Util.canon("Untitled " + i + ".als")))
                 break;
+        fileModifiedDate = -1;
         pane.setText("");
         clearUndo();
         modified = false;
@@ -701,6 +708,7 @@ public final class OurSyntaxWidget {
         String x;
         try {
             x = Util.readAll(filename);
+            fileModifiedDate = Util.getModifiedDate(filename);
         } catch (Throwable ex) {
             OurDialog.alert("Error reading the file \"" + filename + "\"");
             return false;
@@ -728,6 +736,7 @@ public final class OurSyntaxWidget {
         String t;
         try {
             t = Util.readAll(filename);
+            fileModifiedDate = Util.getModifiedDate(filename);
         } catch (Throwable ex) {
             OurDialog.alert("Cannot read \"" + filename + "\"");
             return;
@@ -759,6 +768,11 @@ public final class OurSyntaxWidget {
         }
         this.filename = Util.canon(filename); // a new file's canonical name may
                                              // change
+        try{
+            fileModifiedDate = Util.getModifiedDate(this.filename);
+        }catch(Exception e){
+            fileModifiedDate = new Date().getTime();
+        }
         modified = false;
         isFile = true;
         listeners.fire(this, Event.STATUS_CHANGE);
@@ -782,6 +796,14 @@ public final class OurSyntaxWidget {
             if (f.exists() && !OurDialog.askOverwrite(n))
                 return false;
         }
+
+        if (isFile && n.equals(this.filename) && Util.getModifiedDate(this.filename) > fileModifiedDate) {
+            if (!OurDialog.yesno("The file has been modified outside the editor.\n" +
+                                 "Do you want to overwrite it anyway?")) {
+                return false;
+            }
+        }
+        
         if (saveAs(n, bannedNames)) {
             Util.setCurrentDirectory(new File(filename).getParentFile());
             return true;

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
@@ -768,11 +768,10 @@ public final class OurSyntaxWidget {
         }
         this.filename = Util.canon(filename); // a new file's canonical name may
                                              // change
-        try{
-            fileModifiedDate = Util.getModifiedDate(this.filename);
-        }catch(Exception e){
+        fileModifiedDate = Util.getModifiedDate(this.filename);
+        if (fileModifiedDate == 0)
             fileModifiedDate = new Date().getTime();
-        }
+        
         modified = false;
         isFile = true;
         listeners.fire(this, Event.STATUS_CHANGE);

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/Util.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/Util.java
@@ -302,6 +302,22 @@ public final class Util {
         return convertLineBreak(ans);
     }
 
+    /** Returns the modified date of the given file
+     * (If filename begins with Util.jarPrefix() returns 0) 
+     */
+    public static long getModifiedDate(String filename){
+        String JAR = jarPrefix();
+        boolean fromJar = false;
+        if (filename.startsWith(JAR)) {
+            fromJar = true;
+        }
+        if (! fromJar) {
+            return new File(filename).lastModified();
+        } else {
+            return 0;
+        }
+    }
+
     /**
      * Open then overwrite the file with the given content; throws Err if an error
      * occurred.

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/Util.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/Util.java
@@ -302,20 +302,13 @@ public final class Util {
         return convertLineBreak(ans);
     }
 
-    /** Returns the modified date of the given file
+    /** 
+     * Returns the modified date of the given file
      * (If filename begins with Util.jarPrefix() returns 0) 
      */
     public static long getModifiedDate(String filename){
-        String JAR = jarPrefix();
-        boolean fromJar = false;
-        if (filename.startsWith(JAR)) {
-            fromJar = true;
-        }
-        if (! fromJar) {
-            return new File(filename).lastModified();
-        } else {
-            return 0;
-        }
+        boolean fromJar = filename.startsWith(jarPrefix());
+        return fromJar ? 0 : new File(filename).lastModified(); 
     }
 
     /**


### PR DESCRIPTION
To address #61:
On save, we compare the file modification date on disk with the modification date of the file when it was loaded (field fileModifiedDate), and if the on-disk modification date is newer, a message is shown.

