### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,3 @@ org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4compiler/
 *.out
 *.app
 
-*.iml
-.idea
-
-# Eclipse classpath and project files
-.classpath
-.project


### PR DESCRIPTION
I want to restore the Eclipse metadata since it contains important information for Eclipse users and it is hardly in the way for non-eclipse users. Not sure I understand why this had to be removed? It too me an hour to figure out what was going on.

This is actually quite important for me.