### PR TITLE
Pin osgi.enroute.pom.distro to 2.1.0 rather than 2.1.0-SNAPSHOT

### DIFF
--- a/cnf/ext/enroute-distro.bnd
+++ b/cnf/ext/enroute-distro.bnd
@@ -10,7 +10,7 @@
 	aQute.bnd.repository.maven.pom.provider.BndPomRepository; \
 		snapshotUrls=https://oss.sonatype.org/content/groups/osgi; \
 		releaseUrls=https://repo1.maven.org/maven2/; \
-		revision=org.osgi:osgi.enroute.pom.distro:2.1.0-SNAPSHOT; \
+		revision=org.osgi:osgi.enroute.pom.distro:2.1.0; \
 		name=Distro; \
 		location=${build}/cache/enroute-distro.xml
 


### PR DESCRIPTION
The dependency on osgi.enroute.pom.distro:2.1.0-SNAPSHOT defined [here](https://github.com/AlloyTools/org.alloytools.alloy/blob/87ad5b30250177ed159d4a2033b8c9e188aa448b/cnf/ext/enroute-distro.bnd#L13) means that it's not possible to work on Alloy without an Internet connection.

Is there any reason not to pin to 2.1.0?
All the tests pass locally for me using that dependency rather than the SNAPSHOT.


