### PR TITLE
Make jar work on JDK 11 on Mac

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-bnd_version=3.4.0
+bnd_version=4.2.0

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/MacUtil.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/MacUtil.java
@@ -129,21 +129,4 @@ public final class MacUtil {
             }
         });
     }
-
-    /**
-     * Delegates the call to {@link #addMenus(SimpleGUI)} catching all errors. If no
-     * error is caught, <code>null</code> is returned; otherwise, the caught {@link Error}
-     * is returned.
-     *
-     * Use this method to guard from runtime exceptions thrown when running on newer versions
-     * of OSX that do not support adding OSX-specific menus from Java applications.
-     */
-    public Error tryAddMenus(SimpleGUI simpleGUI) {
-        try {
-            addMenus(simpleGUI);
-            return null;
-        } catch (Error e) {
-            return e;
-        }
-    }
 }

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
@@ -1911,8 +1911,12 @@ public final class SimpleGUI implements ComponentListener, Listener {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
         }
         if (Util.onMac()) {
-            macUtil = new MacUtil();
-            macUtil.tryAddMenus(this);
+            try {
+                macUtil = new MacUtil();
+                macUtil.addMenus(this);
+            } catch (NoClassDefFoundError e) {
+                // ignore
+            }
         }
 
         doLookAndFeel();


### PR DESCRIPTION
Initiating the `MacUtil` generated a `NoClassDefFoundError` on JDK 11 on a Mac. This pull request works around the issue that `com.apple.eawt.*` packages are removed after Java 8. It might be possible in the future to replace the Mac calls with the platform independent set handler methods inside the `java.awt.Desktop`.