### PR TITLE
suggestion: clone URL that works without SSH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Checkout the project and type ./gradlew. You find the executable JAR in org.allo
      java version "1.8.0_144"
      Java(TM) SE Runtime Environment (build 1.8.0_144-b01)
      Java HotSpot(TM) 64-Bit Server VM (build 25.144-b01, mixed model
-     $ git clone git@github.com:AlloyTools/org.alloytools.alloy.git
+     $ git clone https://github.com/AlloyTools/org.alloytools.alloy.git
      $ cd org.alloytools.alloy
      $ ./gradlew build
      $ java -jar org.alloytools.alloy.dist/target/org.alloytools.alloy.dist.jar


### PR DESCRIPTION
It's a public repo, but git@github.com: clone URL still fails authentication.
The https one just works.
Most of us are not going to be pushing to this repo, we just want to install the tool.