### PR TITLE
Specify gradle task consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ JVM to run Alloy on macOS. A `.pkg` file is provided for that purpose.
 
 # TL;DR
 
-Checkout the project and type ./gradlew. You find the executable JAR in org.alloytools.alloy.dist/target/org.alloytools.alloy.dist.jar after the build has finished.
+Checkout the project and type `./gradlew build`. You find the executable JAR in org.alloytools.alloy.dist/target/org.alloytools.alloy.dist.jar after the build has finished.
 
      $ java version           # requires 1.8 (and NOT 1.9, gradle does not run on 1.9)
      java version "1.8.0_144"


### PR DESCRIPTION
Typing ./gradlew only gets me the help.
In the code sample you say `./gradlew build`; consistency will help me not screw it up and get confused