### PR TITLE
Windows build fails with ClassNotFound error

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -63,7 +63,7 @@ set CMD_LINE_ARGS=%*
 :execute
 @rem Setup the command line
 
-set CLASSPATH=$APP_HOME/.gradle-wrapper/gradle-wrapper.jar
+set CLASSPATH=%APP_HOME%/.gradle-wrapper/gradle-wrapper.jar
 
 @rem Execute Gradle
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%


### PR DESCRIPTION
On Windows `gradlew.bat` script fails with error:

```Could not find or load main class org.gradle.wrapper.GradleWrapperMain```

This is because `CLASSPATH` variable has value `$APP_HOME/.gradle-wrapper/gradle-wrapper.jar` and variable `$APP_HOME` is not expanded.

How to fix: replace `$APP_HOME` with `%APP_HOME%`