### PR TITLE
order signatures at table view

### DIFF
--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
@@ -154,17 +154,23 @@ public class TableView {
             TupleSet instanceTuples = instance.tuples(s.label);
             if (instanceTuples != null) {
 
-                List<SimTuple> instancesArray = toArrayList(instanceTuples);
+                List<SimTuple> instancesArray = toList(instanceTuples);
                 Collections.sort(instancesArray, new Comparator<SimTuple>() {
-                        @Override
-                        public int compare(SimTuple simTuple1, SimTuple simTuple2) {
-                            String[] coll1 = simTuple1.get(0).toString().split("\\$");
-                            String[] coll2 = simTuple2.get(0).toString().split("\\$");
-                            if (coll1.length == 2 && coll2.length == 2)
+                    @Override
+                    public int compare(SimTuple simTuple1, SimTuple simTuple2) {
+                        String[] coll1 = simTuple1.get(0).toString().split("\\$");
+                        String[] coll2 = simTuple2.get(0).toString().split("\\$");
+                        if (coll1.length == 2 && coll2.length == 2) {
+                            try {
                                 return Integer.parseInt(coll1[1]) - Integer.parseInt(coll2[1]);
-                            return 0;
+                            }
+                            catch (NumberFormatException e) {
+                                return 0;
+                            }
                         }
-                    });
+                        return 0;
+                    }
+                });
 
                 SimTupleset sigInstances = SimTupleset.make(instancesArray);
                 Table table = new Table(sigInstances.size() + 1, s.getFields().size() + 1, 1);
@@ -269,8 +275,8 @@ public class TableView {
         return SimTuple.make(atoms);
     }
 
-    private static List<SimTuple> toArrayList(TupleSet tupleSet) {
-        List<SimTuple> l = new ArrayList<>();
+    private static List<SimTuple> toList(TupleSet tupleSet) {
+        List<SimTuple> l = new ArrayList<>(tupleSet.size());
         for (Tuple tuple : tupleSet) {
             l.add(toSimTuple(tuple));
         }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
@@ -1,6 +1,8 @@
 package edu.mit.csail.sdg.alloy4;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,7 +154,19 @@ public class TableView {
             TupleSet instanceTuples = instance.tuples(s.label);
             if (instanceTuples != null) {
 
-                SimTupleset sigInstances = toSimTupleset(instanceTuples);
+                List<SimTuple> instancesArray = toArrayList(instanceTuples);
+                Collections.sort(instancesArray, new Comparator<SimTuple>() {
+                        @Override
+                        public int compare(SimTuple simTuple1, SimTuple simTuple2) {
+                            String[] coll1 = simTuple1.get(0).toString().split("\\$");
+                            String[] coll2 = simTuple2.get(0).toString().split("\\$");
+                            if (coll1.length == 2 && coll2.length == 2)
+                                return Integer.parseInt(coll1[1]) - Integer.parseInt(coll2[1]);
+                            return 0;
+                        }
+                    });
+
+                SimTupleset sigInstances = SimTupleset.make(instancesArray);
                 Table table = new Table(sigInstances.size() + 1, s.getFields().size() + 1, 1);
                 table.set(0, 0, s.label);
 
@@ -253,6 +267,14 @@ public class TableView {
             atoms.add(atom);
         }
         return SimTuple.make(atoms);
+    }
+
+    private static List<SimTuple> toArrayList(TupleSet tupleSet) {
+        List<SimTuple> l = new ArrayList<>();
+        for (Tuple tuple : tupleSet) {
+            l.add(toSimTuple(tuple));
+        }
+        return l;
     }
 
     private static SimTupleset toSimTupleset(TupleSet tupleSet) {


### PR DESCRIPTION
The order of the atoms at the table view for more than 10 atoms (for
the same signature) was confusing because it was only being sorted by
the string itself without taking in consideration the index after `$`.

I'am using the following code as an example
```alloy
module Eita
open util/ordering[Time]

sig Time {
	state: one State
}

sig State {}

run {} for 20

```

Before the table was like
![Screenshot from 2020-09-26 15-32-32](https://user-images.githubusercontent.com/2124834/94347779-82904580-000d-11eb-927e-84ba5b835743.png)

Now it's like
![Screenshot from 2020-09-26 15-23-01](https://user-images.githubusercontent.com/2124834/94347754-3c3ae680-000d-11eb-9478-45cab47315b6.png)

If you don't need it to be solved or think this is not a problem, fell free to close. 

Thank you for this awesome project =D