### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - curl -N -L "http://es-static.fbk.eu/tools/nuxmv/downloads/nuXmv-2.0.0-linux64.tar.gz" | tar --extract --gzip --strip-components=2 -C $HOME/bin "nuXmv-2.0.0-Linux/bin/nuXmv" || true
 install: 
   - "gradle --version"
-script: travis_wait gradle --no-daemon -DGRADLE_OPTS="-Xms128m" --stacktrace build -i
+script: gradle --no-daemon -DGRADLE_OPTS="-Xms128m" --stacktrace build -i
 cache:
   directories:
   - "$HOME/.gradle"


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
