### PR TITLE
Fix type errors in util/sequence.als

### DIFF
--- a/org.alloytools.alloy.core/src/main/resources/models/util/sequence.als
+++ b/org.alloytools.alloy.core/src/main/resources/models/util/sequence.als
@@ -122,7 +122,7 @@ pred startsWith [s, prefix: Seq] {
 pred add [s: Seq, e: elem, added: Seq] {
   added.startsWith[s]
   added.seqElems[s.afterLastIdx] = e
-  #added.inds = #s.inds.add[1]
+  #added.inds = (#s.inds).add[1]
 }
 
 /** setted is the result of setting value at index i to e */
@@ -135,7 +135,7 @@ pred insert [s: Seq, idx: SeqIdx, e: elem, inserted: Seq] {
   inserted.at[idx] = e
   all i: ord/prevs[idx] | inserted.at[i] = s.at[i]
   all i: ord/nexts[idx] | inserted.at[i] = s.at[ord/prev[i]]
-  #inserted.inds = #s.inds.add[1]
+  #inserted.inds = (#s.inds).add[1]
 }
 
 /** copies source into dest starting at destStart */
@@ -151,7 +151,7 @@ pred copy [source, dest: Seq, destStart: SeqIdx] {
 pred append [s1, s2, appended: Seq] {
   appended.startsWith[s1]
   copy[s2, appended, s1.afterLastIdx]
-  #appended.inds = #s1.inds.add[#s2.inds]
+  #appended.inds = (#s1.inds).add[#s2.inds]
 }
 
 /** sub is the subsequence of s between from and to, inclusive */


### PR DESCRIPTION
Fixes a bug (type errors likely introduced when changing the syntax of arithmetic operations) reported at https://alloytools.discourse.group/t/util-sequence-type-error/185/3 .