### PR TITLE
Add LSP implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ enroute.zip
 
 .idea
 *.iml
+.classpath
+.project
+*.prefs
+.settings/
+
+*.jar
+.vscode

--- a/cnf/central.mvn
+++ b/cnf/central.mvn
@@ -9,3 +9,8 @@ org.alloytools:pardinus.core:1.3.0
 org.alloytools:pardinus.nativesat:1.3.0
 biz.aQute:biz.aQute.wrapper.hamcrest:1.3
 biz.aQute:biz.aQute.wrapper.junit:4.13.1
+org.eclipse.lsp4j:org.eclipse.lsp4j:0.4.1
+org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.4.1
+org.eclipse.equinox:org.eclipse.equinox.common:jar:3.6.0
+commons-io:commons-io:jar:2.6
+com.google.code.gson:gson:2.8.9

--- a/org.alloytools.alloy.application/bnd.bnd
+++ b/org.alloytools.alloy.application/bnd.bnd
@@ -5,6 +5,11 @@
 	lib/apple-osx-ui.jar;version=file,\
 	org.alloytools:pardinus.core;version=1.3.0,\
 	org.alloytools.alloy.core;version=latest,\
+	org.eclipse.lsp4j,\
+	org.eclipse.lsp4j.jsonrpc,\
+	com.google.gson,\
+	org.eclipse.equinox.common, \
+	org.apache.commons.io
 
 -testpath: \
 	biz.aQute.wrapper.junit, \

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyAppUtil.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyAppUtil.java
@@ -1,0 +1,124 @@
+package edu.mit.csail.sdg.alloy4whole;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+
+import edu.mit.csail.sdg.alloy4.Err;
+import edu.mit.csail.sdg.alloy4.ErrorFatal;
+import edu.mit.csail.sdg.alloy4.OurDialog;
+import edu.mit.csail.sdg.alloy4.Util;
+import edu.mit.csail.sdg.ast.ExprVar;
+import edu.mit.csail.sdg.ast.Module;
+import edu.mit.csail.sdg.ast.Sig;
+import edu.mit.csail.sdg.ast.Sig.Field;
+import edu.mit.csail.sdg.sim.SimInstance;
+import edu.mit.csail.sdg.sim.SimTuple;
+import edu.mit.csail.sdg.sim.SimTupleset;
+import edu.mit.csail.sdg.translator.A4Solution;
+import edu.mit.csail.sdg.translator.A4Tuple;
+import edu.mit.csail.sdg.translator.A4TupleSet;
+
+public class AlloyAppUtil {
+
+	/**
+	 * This variable caches the result of alloyHome() function call.
+	 */
+	private static String alloyHome = null;
+
+	/**
+	 * Find a temporary directory to store Alloy files; it's guaranteed to be a
+	 * canonical absolute path.
+	 */
+	public static synchronized String alloyHome() {
+		if (alloyHome != null)
+			return alloyHome;
+		String temp = System.getProperty("java.io.tmpdir");
+		if (temp == null || temp.length() == 0)
+			OurDialog.fatal(null, "Error. JVM need to specify a temporary directory using java.io.tmpdir property.");
+		String username = System.getProperty("user.name");
+		File tempfile = new File(temp + File.separatorChar + "alloy4tmp40-" + (username == null ? "" : username));
+		tempfile.mkdirs();
+		String ans = Util.canon(tempfile.getPath());
+		if (!tempfile.isDirectory()) {
+			OurDialog.fatal(null, "Error. Cannot create the temporary directory " + ans);
+		}
+		if (!Util.onWindows()) {
+			String[] args = { "chmod", "700", ans };
+			try {
+				Runtime.getRuntime().exec(args).waitFor();
+			} catch (Throwable ex) {
+			} // We only intend to make a best effort.
+		}
+		return alloyHome = ans;
+	}
+	
+	/**
+	 * Create an empty temporary directory for use, designate it "deleteOnExit",
+	 * then return it. It is guaranteed to be a canonical absolute path.
+	 */
+	public static String maketemp() {
+		Random r = new Random(new Date().getTime());
+		while (true) {
+			int i = r.nextInt(1000000);
+			String dest = AlloyAppUtil.alloyHome() + File.separatorChar + "tmp" + File.separatorChar + i;
+			File f = new File(dest);
+			if (f.mkdirs()) {
+				f.deleteOnExit();
+				return Util.canon(dest);
+			}
+		}
+	}
+	
+    /** Converts an A4TupleSet into a SimTupleset object. */
+    public static SimTupleset convert(Object object) throws Err {
+        if (!(object instanceof A4TupleSet))
+            throw new ErrorFatal("Unexpected type error: expecting an A4TupleSet.");
+        A4TupleSet s = (A4TupleSet) object;
+        if (s.size() == 0)
+            return SimTupleset.EMPTY;
+        List<SimTuple> list = new ArrayList<SimTuple>(s.size());
+        int arity = s.arity();
+        for (A4Tuple t : s) {
+            String[] array = new String[arity];
+            for (int i = 0; i < t.arity(); i++)
+                array[i] = t.atom(i);
+            list.add(SimTuple.make(array));
+        }
+        return SimTupleset.make(list);
+    }
+
+    /** Converts an A4Solution into a SimInstance object. */
+    public static SimInstance convert(Module root, A4Solution ans) throws Err {
+        SimInstance ct = new SimInstance(root, ans.getBitwidth(), ans.getMaxSeq());
+        for (Sig s : ans.getAllReachableSigs()) {
+            if (!s.builtin)
+                ct.init(s, convert(ans.eval(s)));
+            for (Field f : s.getFields())
+                if (!f.defined)
+                    ct.init(f, convert(ans.eval(f)));
+        }
+        for (ExprVar a : ans.getAllAtoms())
+            ct.init(a, convert(ans.eval(a)));
+        for (ExprVar a : ans.getAllSkolems())
+            ct.init(a, convert(ans.eval(a)));
+        return ct;
+    }
+
+    
+	public interface Func0<T> {
+		public T call() throws Exception;
+	}
+	public static <T> T uncheckedRun(Func0<T> func) {
+		try {
+			return func.call();
+		} catch(RuntimeException e) {
+			throw e;
+		} catch(Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLSMessage.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLSMessage.java
@@ -1,0 +1,30 @@
+package edu.mit.csail.sdg.alloy4whole;
+
+public class AlloyLSMessage {
+	public AlloyLSMessageType messageType;
+	public String message;
+	public String link;
+	
+	public boolean bold;
+	public boolean replaceLast;
+	public boolean lineBreak = true;
+	
+	public AlloyLSMessage(AlloyLSMessageType messageType, String message, String link) {
+		this.messageType = messageType;
+		this.message = message;
+		this.link = link;
+	}
+	
+	public AlloyLSMessage(AlloyLSMessageType messageType, String message) {
+		this(messageType, message, null);
+	}
+	
+}
+
+enum AlloyLSMessageType{
+	RunStarted,
+	RunInProgress,
+	RunResult,
+	RunCompleted,
+	Warning
+}

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageClient.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageClient.java
@@ -1,0 +1,39 @@
+package edu.mit.csail.sdg.alloy4whole;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+public interface AlloyLanguageClient extends LanguageClient {
+	@JsonNotification("alloy/showExecutionOutput")
+	CompletableFuture<?> showExecutionOutput(AlloyLSMessage params);
+	
+	@JsonNotification("alloy/commandsListResult")
+	CompletableFuture<?> commandsListResult(CommandsListResult commands);
+
+	public class CommandsListResult{
+		public List<CommandsListResultItem> commands;
+
+		public CommandsListResult(List<CommandsListResultItem> commands) {
+			this.commands = commands;
+		}
+		
+	}
+	public class CommandsListResultItem{
+		public String title;
+		public Command command;
+
+		public CommandsListResultItem(String title, Command command) {
+			this.title = title;
+			this.command = command;
+		}
+		
+	}
+}

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageServer.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageServer.java
@@ -1,0 +1,1713 @@
+package edu.mit.csail.sdg.alloy4whole;
+
+import static edu.mit.csail.sdg.alloy4.A4Preferences.AutoVisualize;
+
+import static edu.mit.csail.sdg.alloy4whole.AlloyLanguageServerUtil.*;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.CoreGranularity;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.CoreMinimization;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.ImplicitThis;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.InferPartialInstance;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.NoOverflow;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.RecordKodkod;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.SkolemDepth;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.Solver;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.SubMemory;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.SubStack;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.Unrolls;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.VerbosityPref;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.WarningNonfatal;
+
+import java.awt.event.MouseEvent;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.alloytools.alloy.core.AlloyCore;
+import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.CodeLens;
+import org.eclipse.lsp4j.CodeLensOptions;
+import org.eclipse.lsp4j.CodeLensParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.DidChangeConfigurationParams;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
+import org.eclipse.lsp4j.DocumentLink;
+import org.eclipse.lsp4j.DocumentLinkOptions;
+import org.eclipse.lsp4j.DocumentLinkParams;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
+import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.WorkspaceFoldersOptions;
+import org.eclipse.lsp4j.WorkspaceServerCapabilities;
+import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageClientAware;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonPrimitive;
+
+import edu.mit.csail.sdg.alloy4.A4Reporter;
+import edu.mit.csail.sdg.alloy4.Computer;
+import edu.mit.csail.sdg.alloy4.ConstList;
+import edu.mit.csail.sdg.alloy4.Err;
+import edu.mit.csail.sdg.alloy4.ErrorFatal;
+import edu.mit.csail.sdg.alloy4.ErrorSyntax;
+import edu.mit.csail.sdg.alloy4.ErrorType;
+import edu.mit.csail.sdg.alloy4.ErrorWarning;
+import edu.mit.csail.sdg.alloy4.OurDialog;
+import edu.mit.csail.sdg.alloy4.OurSyntaxWidget;
+import edu.mit.csail.sdg.alloy4.OurUtil;
+import edu.mit.csail.sdg.alloy4.Pair;
+import edu.mit.csail.sdg.alloy4.Pos;
+import edu.mit.csail.sdg.alloy4.Runner;
+import edu.mit.csail.sdg.alloy4.Util;
+import edu.mit.csail.sdg.alloy4.Version;
+import edu.mit.csail.sdg.alloy4.WorkerEngine;
+import edu.mit.csail.sdg.alloy4.XMLNode;
+import edu.mit.csail.sdg.alloy4.WorkerEngine.WorkerCallback;
+import edu.mit.csail.sdg.alloy4viz.VizGUI;
+import edu.mit.csail.sdg.alloy4.A4Preferences.Verbosity;
+import edu.mit.csail.sdg.alloy4whole.AlloyLanguageClient.CommandsListResult;
+import edu.mit.csail.sdg.alloy4whole.AlloyLanguageClient.CommandsListResultItem;
+import edu.mit.csail.sdg.alloy4whole.SimpleReporter.SimpleCallback1;
+import edu.mit.csail.sdg.alloy4whole.SimpleReporter.SimpleTask1;
+import edu.mit.csail.sdg.alloy4whole.SimpleReporter.SimpleTask2;
+import edu.mit.csail.sdg.ast.Assert;
+import edu.mit.csail.sdg.ast.Clause;
+import edu.mit.csail.sdg.ast.CommandScope;
+import edu.mit.csail.sdg.ast.Expr;
+import edu.mit.csail.sdg.ast.ExprBad;
+import edu.mit.csail.sdg.ast.ExprConstant;
+import edu.mit.csail.sdg.ast.ExprHasName;
+import edu.mit.csail.sdg.ast.ExprLet;
+import edu.mit.csail.sdg.ast.ExprUnary;
+import edu.mit.csail.sdg.ast.ExprVar;
+import edu.mit.csail.sdg.ast.Func;
+import edu.mit.csail.sdg.ast.Module;
+import edu.mit.csail.sdg.ast.Sig;
+import edu.mit.csail.sdg.ast.VisitQueryOnce;
+import edu.mit.csail.sdg.ast.Sig.Field;
+import edu.mit.csail.sdg.parser.CompModule;
+import edu.mit.csail.sdg.parser.CompUtil;
+import edu.mit.csail.sdg.parser.Macro;
+import edu.mit.csail.sdg.sim.SimInstance;
+import edu.mit.csail.sdg.sim.SimTuple;
+import edu.mit.csail.sdg.sim.SimTupleset;
+import edu.mit.csail.sdg.translator.A4Options;
+import edu.mit.csail.sdg.translator.A4Solution;
+import edu.mit.csail.sdg.translator.A4SolutionReader;
+import edu.mit.csail.sdg.translator.A4Tuple;
+import edu.mit.csail.sdg.translator.A4TupleSet;
+import kodkod.engine.fol2sat.HigherOrderDeclException;
+
+import org.apache.commons.io.*;
+
+import static edu.mit.csail.sdg.alloy4whole.Lsp4jUtil.*;
+
+import static edu.mit.csail.sdg.alloy4whole.AlloyLSMessageType.*;
+public class AlloyLanguageServer implements LanguageServer, LanguageClientAware {
+
+	private AlloyLanguageClient client;
+	private AlloyTextDocumentService alloyTextDocumentService;
+
+	@Override
+	public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+
+		service().directory = params.getRootUri() != null ? fileUriToPath(params.getRootUri()) : null;
+
+		InitializeResult res = new InitializeResult();
+		ServerCapabilities caps = new ServerCapabilities();
+
+		caps.setTextDocumentSync(Either.forLeft(TextDocumentSyncKind.Full));
+		
+		caps.setDefinitionProvider(true);
+		caps.setHoverProvider(true);
+		caps.setCodeLensProvider(new CodeLensOptions());
+		caps.setDocumentLinkProvider(new DocumentLinkOptions() );
+		caps.setReferencesProvider(true);
+		caps.setRenameProvider(true);
+		//caps.setDocumentHighlightProvider(true);
+		caps.setWorkspaceSymbolProvider(true);
+		caps.setDocumentSymbolProvider(true);
+
+		res.setCapabilities(caps);
+		return CompletableFuture.completedFuture(res);
+	}
+
+	@Override
+	public CompletableFuture<Object> shutdown() {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public void exit() {
+		System.exit(0);
+	}
+
+	@Override
+	public TextDocumentService getTextDocumentService() {
+		return service();
+	}
+
+	private AlloyTextDocumentService service() {
+		if (alloyTextDocumentService == null)
+			alloyTextDocumentService = new AlloyTextDocumentService(client);
+		return alloyTextDocumentService;
+	}
+
+	@Override
+	public WorkspaceService getWorkspaceService() {
+		return service();
+	}
+
+	
+
+	// LanguageClientAware
+	@Override
+	public void connect(LanguageClient client) {
+		System.out.println("AlloyLanguageServer.connect() called");
+		this.client = (AlloyLanguageClient) client;
+
+		if (this.alloyTextDocumentService != null) {
+			this.alloyTextDocumentService.connect(this.client);
+		}
+
+	}
+
+}
+
+class AlloyTextDocumentService implements TextDocumentService, WorkspaceService, LanguageClientAware {
+
+	public AlloyLanguageClient client;
+	public String directory;
+	private int subMemoryNow;
+	private int subStackNow;
+
+	public AlloyTextDocumentService( AlloyLanguageClient client) {
+		this.client = client;
+	}
+
+	// LanguageClientAware
+	@Override
+	public void connect(LanguageClient client) {
+		log("AlloyTextDocumentService.connect() called");
+		this.client = (AlloyLanguageClient) client;
+	}
+
+	@Override
+	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
+		return CompletableFuture.completedFuture(unresolved);
+	}
+
+	Either<CompModule, Err> cachedCompModuleForFileUri = null;
+
+	/**
+	 * the file uri of the cached module. If this is not null, the cached module
+	 * is valid for the uri
+	 */
+	String cachedCompModuleForFileUri_Uri = null;
+
+	CompModule getCompModuleForFileUri(String uri) {
+		// log("getCompModuleForFileUri (" + uri + ")");
+		if(uri.equals(cachedCompModuleForFileUri_Uri)){
+			return getResult(cachedCompModuleForFileUri);
+		}
+		
+		try {
+			String path = fileUriToPath(uri);
+			
+			// Try to return a nullModule object for non-AlloyMarkdown files.
+			// Not a big deal if the file has not been cached
+			String contents = fileContents.get(uri);
+			if (contents != null && !isAlloyFile(path, contents)) {
+				return CompUtil.nullModule();
+			}
+			
+			cachedCompModuleForFileUri = Either.forLeft(CompUtil.parseEverything_fromFile(null, fileContentsPathBased(), path, 2));
+			
+		} catch (Err err) {
+			log("getCompModuleForFileUri(): error in parsing: " + err.toString());
+			fileUrisOfLastPublishedDiagnostics.add(uri);
+			
+			client.publishDiagnostics(toPublishDiagnosticsParams(err));
+
+			if(err instanceof ErrorSyntax)
+				latestFileUrisWithSyntaxError.add(uri);
+			
+			cachedCompModuleForFileUri = Either.forRight(err);
+			throw err;
+		}
+
+		if (latestFileUrisWithSyntaxError.contains(uri)) {
+			client.publishDiagnostics(newPublishDiagnosticsParams(uri, Arrays.asList()));
+			latestFileUrisWithSyntaxError.remove(uri);
+		}
+		cachedCompModuleForFileUri_Uri = uri;
+		return getResult(cachedCompModuleForFileUri);
+	}
+
+	@Override
+	public CompletableFuture<Hover> hover(TextDocumentPositionParams position) {
+		//log("hover request");
+		String hoverStr = null;
+		try {
+			
+			String uri = position.getTextDocument().getUri();
+			String text = fileContents.get(uri);
+			CompModule module = getCompModuleForFileUri(uri);
+			
+			Pos pos = positionToPos(position.getPosition());
+			Expr expr = module.find(pos);
+			if (expr instanceof ExprBad) {
+				hoverStr =  expr.toString();
+			}
+			else if (expr != null) {
+				Clause referenced = expr.referenced();
+				if (referenced != null) {
+					hoverStr = referenced.explain();
+				} else if (expr instanceof ExprConstant) {
+					String token = pos.substring(text);
+					if (token != null) {
+						String match = expr.toString();
+						if (!Objects.equals(token, match))
+							hoverStr =  match;
+					}
+				}
+			}
+		} catch (Exception e) {
+			// ignore compile errors etc.
+		}
+		if(hoverStr != null) {
+			MarkupContent markupContent = new MarkupContent();
+			markupContent.setKind("markdown");
+			
+			hoverStr = "```\n" + hoverStr + "\n```";
+				
+			markupContent.setValue(hoverStr);
+			Hover res = new Hover();
+			res.setContents(markupContent);
+			return CompletableFuture.completedFuture(res);			
+		}else {
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	@Override
+	public CompletableFuture<SignatureHelp> signatureHelp(TextDocumentPositionParams position) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<List<? extends Location>> definition(TextDocumentPositionParams position) {
+		try {
+			String uri = position.getTextDocument().getUri();
+			String text = fileContents.get(uri);
+			String path = fileUriToPath(uri);
+
+			CompModule module = getCompModuleForFileUri(uri);
+			Pos pos = positionToPos(position.getPosition(), path);
+			pos = getCurrentWordSelectionAsPos(text, pos);
+			Expr expr = module.find(pos);
+
+			log("definition request for: " + expr);
+			
+            if (expr != null) {
+                Clause clause = expr.referenced();
+                if (clause != null) {
+                    Pos where = clause.pos();
+                    
+                    //if path includes the jar, replace it by the created temp dir containing alloy models
+                    String fileName =  filePathResolved(where.filename);
+                    
+                    String targetUri = where.sameFile(module.pos()) ? uri : filePathToUri(fileName);
+                    Location res = newLocation(createRangeFromPos(where), targetUri);
+                    return CompletableFuture.completedFuture(Arrays.asList(res));
+                }
+            }
+
+		}catch(Exception ex) {
+			System.err.println("Error in providing definition: " + ex.toString());
+		}
+		return CompletableFuture.completedFuture(Arrays.asList());
+	}
+
+
+
+	@Override
+	public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
+
+		String uri = params.getTextDocument().getUri();
+		String text = fileContents.get(uri);
+		String path = fileUriToPath(uri);
+
+		try{	
+			CompModule module = getCompModuleForFileUri(params.getTextDocument().getUri());
+
+			Pos pos = getPosOfSymbolFromPositionInOpenDoc(params.getTextDocument().getUri(), params.getPosition());
+			pos = getCurrentWordSelectionAsPos(text, pos).withFilename(path);
+			
+			String dir = this.directory != null ? this.directory : new File(path).getParent();
+			List<Location> res = findAllReferencesGlobally(module, pos, dir, true, true).stream()
+				.map(ref -> posToLocation(ref))
+				.collect(Collectors.toList());
+			return CompletableFuture.completedFuture(res);
+		} catch(Err err){
+			client.showMessage(
+				newMessageParams("There are errors. Fix them first.", MessageType.Warning));
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	@Override
+	public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
+		String uri = params.getTextDocument().getUri();
+		String text = fileContents.get(uri);
+		String path = fileUriToPath(uri);
+
+		try{
+			CompModule module = getCompModuleForFileUri(uri);
+			
+			Pos pos = getPosOfSymbolFromPositionInOpenDoc(uri, params.getPosition());
+			pos = getCurrentWordSelectionAsPos(text, pos).withFilename(path);
+
+			Expr expr = module.find(pos);
+			Pos targetPos = expr.referenced() != null ? expr.referenced().pos() : expr.pos;
+			
+			CompModule targetModule = CompUtil.parseEverything_fromFile(null, fileContentsPathBased(), filePathResolved(targetPos.filename));
+			
+			Expr targetExpr = targetModule.find(targetPos);
+
+			Map<String, List<TextEdit>> changes = new HashMap<>();
+				
+			String dir = this.directory != null ? this.directory : new File(path).getParent();
+			List<Pos> refs = findAllReferencesGlobally(module, pos, dir, false, false);
+			
+			if (targetExpr instanceof Sig){
+				targetPos = ((Sig)targetExpr).labelPos;
+			} else if (targetExpr instanceof Field){
+				targetPos = ((Field) targetExpr).labelPos;
+			} else if ( targetExpr instanceof Func){
+				targetPos = ((Func) targetExpr).labelPos;
+			} else if (targetExpr instanceof Assert){
+				targetPos = ((Assert) targetExpr).labelPos;
+			} else if (targetExpr instanceof Macro){
+				targetPos = ((Macro) targetExpr).namePos;
+			}
+			
+			WorkspaceEdit wEdit = new WorkspaceEdit();
+			Stream.concat(refs.stream().distinct(), Stream.of(targetPos)).forEach(refPos ->{
+				TextEdit edit = new TextEdit();
+
+				edit.setRange(createRangeFromPos(refPos));
+				edit.setNewText(params.getNewName());
+				
+				String refUri = filePathToUri(filePathResolved(refPos.filename));
+				
+				if(!changes.containsKey(refUri))
+					changes.put(refUri, new ArrayList<>());
+				changes.get(refUri).add(edit);
+			});
+			
+			wEdit.setChanges(changes);
+
+			return CompletableFuture.completedFuture(wEdit);
+
+		} catch(Err err){
+			client.showMessage(
+				newMessageParams("Cannot rename symbol while there are errors. Fix the errors first.", MessageType.Warning));
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	Pos getPosOfSymbolFromPositionInOpenDoc(String uri, Position position){
+		String path = fileUriToPath(uri);
+		String text = fileContents.get(uri);
+		
+		Pos pos = positionToPos(position, path);
+		pos = getCurrentWordSelectionAsPos(text, pos);
+		return pos;
+	}
+
+	@Override
+	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(TextDocumentPositionParams position) {
+		
+		try{
+			CompModule module = getCompModuleForFileUri(position.getTextDocument().getUri());
+			
+			Pos pos = getPosOfSymbolFromPositionInOpenDoc(position.getTextDocument().getUri(), position.getPosition());
+			List<Expr> refs = findAllReferences(module, pos, true);
+			
+			String path = fileUriToPath(position.getTextDocument().getUri());
+			List<DocumentHighlight> res = refs.stream()
+				.filter(ref -> path.equals(ref.pos.filename))
+				.map(ref -> {
+					DocumentHighlight highlight = new DocumentHighlight();
+					
+					highlight.setKind(DocumentHighlightKind.Text);
+					highlight.setRange(createRangeFromPos(ref.pos));
+					return highlight;
+				}).collect(Collectors.toList());
+			
+			return CompletableFuture.completedFuture(res);
+
+		}catch(Exception ex){
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	@Override
+	public CompletableFuture<List<? extends SymbolInformation>> documentSymbol(DocumentSymbolParams params) {
+		try{
+			CompModule module = getCompModuleForFileUri(params.getTextDocument().getUri());
+			return CompletableFuture.completedFuture(moduleSymbols(module));
+		}catch(Exception ex){
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	private List<SymbolInformation> folderSymbols(String dir){
+		List<SymbolInformation> res = new ArrayList<>();
+		
+		for(File child : alloyFilesInDir(dir)){
+			String filePath = fileUriToPath(child.toURI().toString());
+			try{
+				CompModule module = CompUtil.parseEverything_fromFile(null, fileContentsPathBased(), filePath);
+				res.addAll(moduleSymbols(module));
+			} catch(Exception ex){
+				log("error parsing " + child);
+			}
+		}
+
+		return res;		
+	}
+
+	private static List<SymbolInformation> moduleSymbols(CompModule module){
+		Stream<SymbolInformation> commands = module.getAllCommands().stream()
+				.map(c -> newSymbolInformation(c.label, posToLocation(c.pos), SymbolKind.Event));
+
+		Stream<SymbolInformation> sigs = module.getAllSigs().makeConstList().stream()
+				.map(sig -> newSymbolInformation(sig.label, posToLocation(sig.pos), 
+												 sig.isEnum != null ? SymbolKind.Enum :
+												 sig.isEnumMember() ? SymbolKind.EnumMember : 
+				                                 sig.isOne != null || sig.isLone != null ? SymbolKind.Object :
+				                                 SymbolKind.Class));
+
+		Stream<SymbolInformation> fields = module.getAllSigs().makeConstList().stream()
+				.flatMap(sig -> sig.getFields().makeConstList().stream()).map(field -> {
+					SymbolInformation symbolInfo = newSymbolInformation(field.label, posToLocation(field.pos),
+							SymbolKind.Field);
+					symbolInfo.setContainerName(removeThisPrefix(field.sig.label));
+					return symbolInfo;
+				});
+
+		Stream<SymbolInformation> funcs = module.getAllFunc().makeConstList().stream()
+				.map(func -> newSymbolInformation(func.label, posToLocation(func.pos), 
+												  func.isPred ? SymbolKind.Boolean : SymbolKind.Function));
+
+		Stream<SymbolInformation> macros = module.getAllMacros().makeConstList().stream().map( macro -> 
+			newSymbolInformation(macro.name, posToLocation(macro.pos), SymbolKind.Constructor)
+		);
+
+		Stream<SymbolInformation> assertions = module.getAllAssertions().stream().map(
+				assertion -> newSymbolInformation(assertion.label, posToLocation(assertion.pos), SymbolKind.Property));
+
+		return 
+			Stream.of(commands, sigs, fields, funcs, assertions, macros)
+			.flatMap(x -> x)
+			.map(x -> {x.setName(removeThisPrefix(x.getName())); return x;})
+			//.sorted((sym1,sym2) -> positionCompare(sym1.getLocation().getRange().getStart(), sym2.getLocation().getRange().getStart()))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public CompletableFuture<List<? extends Command>> codeAction(CodeActionParams params) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	List<Pair<edu.mit.csail.sdg.ast.Command,Command>> getCommands(String uri) {
+		CompModule module;
+
+		try {
+			module = getCompModuleForFileUri(uri);
+		} catch (Exception e) {
+			return Arrays.asList();
+		}
+
+		ConstList<edu.mit.csail.sdg.ast.Command> commands = module.getAllCommands();
+		
+		ArrayList<Pair<edu.mit.csail.sdg.ast.Command,Command>> res = new ArrayList<>();
+
+		for (int i = 0; i < commands.size(); i++) {
+			edu.mit.csail.sdg.ast.Command command = commands.get(i);
+			Position position = posToPosition(command.pos);
+			CodeLens codeLens = new CodeLens();
+			codeLens.setRange(createRange(position, position));
+			Command vsCommand = new Command("Execute", "ExecuteAlloyCommand"); 
+			vsCommand.setArguments(
+					Arrays.asList(uri, i, position.getLine(), position.getCharacter()));
+			codeLens.setCommand(vsCommand);
+
+			res.add(new Pair<>(command, vsCommand) );
+		}
+		
+		if (latestFileUrisWithSyntaxError.contains(uri)) {
+			client.publishDiagnostics(newPublishDiagnosticsParams(uri, Arrays.asList()));
+			latestFileUrisWithSyntaxError.remove(uri);
+		}
+		return res;
+	}
+	
+	@Override
+	public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
+				
+		List<CodeLens> res = getCommands(params.getTextDocument().getUri()).stream().map(pair -> {
+			edu.mit.csail.sdg.ast.Command command = pair.a;
+			Command vsCommand = pair.b;
+			
+			CodeLens codeLens = new CodeLens();
+			codeLens.setRange(createRangeFromPos(command.pos));
+			codeLens.setCommand(vsCommand);
+			
+			return codeLens;
+		}).collect(Collectors.toList());
+		
+		return CompletableFuture.completedFuture(res);
+	}
+	
+	@Override
+	public CompletableFuture<List<DocumentLink>> documentLink(DocumentLinkParams params) {
+		
+		List<DocumentLink> links = getCommands(params.getTextDocument().getUri()).stream().map(pair -> {
+			edu.mit.csail.sdg.ast.Command command = pair.a;
+			Command vsCommand = pair.b;
+			
+			DocumentLink link = new DocumentLink();
+			link.setRange(createRangeFromPos(command.commandKeyword.pos));
+			List<Object> args = vsCommand.getArguments();
+			Gson gson = new Gson();
+			try {
+				java.net.URI path = new java.net.URI((String) args.get(0));
+				args.set(0, path.toString());
+				System.out.println("gson.toJson(args): " + gson.toJson(args));
+				link.setTarget("command:" + vsCommand.getCommand() + "?" + gson.toJson(args));
+					// URLEncoder.encode(gson.toJson(args), "UTF-8") );
+			// } catch (UnsupportedEncodingException e1) {
+			} catch (URISyntaxException e) {}
+			
+			return link;
+		}).collect(Collectors.toList());
+		
+		return CompletableFuture.completedFuture(links);
+
+	}
+	
+	@JsonRequest
+	public CompletableFuture<Void> ListAlloyCommands(JsonPrimitive documentUri){
+		log("ListAlloyCommands called with " + documentUri +", of type " + documentUri.getClass().getName() );
+		List<CommandsListResultItem> res = 
+				getCommands(documentUri.getAsString()).stream()
+				.map( pair -> new CommandsListResultItem(pair.a.toString() , pair.b))
+				.collect(Collectors.toList());
+
+		client.commandsListResult(new CommandsListResult(res));
+		return CompletableFuture.completedFuture(null);
+	}
+	
+	private final HashSet<String> fileUrisOfLastPublishedDiagnostics = new HashSet<>();
+	private final Set<String> latestFileUrisWithSyntaxError = new HashSet<>();
+
+	@JsonRequest
+	public CompletableFuture<Void> ExecuteAlloyCommand(com.google.gson.JsonArray params) {
+		log("ExecuteAlloyCommand() called with " + params + ", " + params.getClass());
+		String uri = params.get(0).getAsString();
+		int ind = params.get(1).getAsInt();
+		int line = params.get(2).getAsInt(), character = params.get(3).getAsInt();
+
+		Position position = new Position(line, character);
+		Pos pos = positionToPos(position);
+		String fileString = fileContents.get(uri);
+		// Ugly hack to make the uri look like what it was if invoked through links
+		// if (fileString == null) {
+		// 	java.net.URI uriObj = new java.net.URI(uri);
+		// 	String newPath =  uriObj.getRawPath().replace(":", "%3A");
+		// 	String newUri = uriObj.getScheme() + newPath;
+		// 	fileString = fileContents.get(newUri);
+		// }
+		// Another ugly hack to make things work if invoked through links (which makes the uri look different)
+		if (fileString == null) {
+			String uriPath = fileUriToPath(uri);
+			for (Map.Entry<String, String> entry : fileContents.entrySet()) {
+				if(fileUriToPath(entry.getKey()).equals(uriPath)){
+					fileString = entry.getValue();
+					uri = entry.getKey();
+					break;
+				}
+			}
+		}
+		if(fileString == null) {
+			System.err.println("Error in ExecuteAlloyCommand: failed to retrieve file contents for " + uri);
+			return CompletableFuture.completedFuture(null);
+		}
+		CompModule module = CompUtil.parseOneModule(fileString);
+		ConstList<edu.mit.csail.sdg.ast.Command> commands = module.getAllCommands();
+		edu.mit.csail.sdg.ast.Command command = commands.stream()
+				.filter(comm -> comm.pos().y == pos.y && comm.pos.x == pos.x).findFirst().orElse(null);
+		if (command != null || ind == -1) {
+			String uriToShutUpStupidJava = uri;
+			CompletableFuture.runAsync(() -> doRun(uriToShutUpStupidJava, ind));
+		} else {
+			System.err.println("no matching command found");
+		}
+
+		return CompletableFuture.completedFuture(null);
+	}
+	
+	@JsonRequest
+	public CompletableFuture<Void> StopExecution(Object o) {
+		log("Stop req received");
+		doStop(2);
+		
+		AlloyLSMessage alloyMsg = new AlloyLSMessage(RunCompleted, "Stopped");
+		alloyMsg.bold = true;
+		client.showExecutionOutput(alloyMsg);
+
+		return CompletableFuture.completedFuture(null);
+	}
+	
+	@JsonRequest
+	public CompletableFuture<Void> OpenModel(com.google.gson.JsonPrimitive link) {
+		log("OpenModel() called with " + link.getAsString());
+		log(" , of type" + link.getClass().getName());
+		doVisualize(link.getAsString());
+		return CompletableFuture.completedFuture(null);
+	}
+	
+
+	
+	@Override
+	public CompletableFuture<CodeLens> resolveCodeLens(CodeLens unresolved) {
+		return CompletableFuture.completedFuture(unresolved);
+	}
+
+	@Override
+	public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(DocumentOnTypeFormattingParams params) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+
+	private Map<String,String> fileContentsPathBased(){
+		HashMap<String, String> res = new HashMap<String,String>();
+		fileContents.entrySet().stream()
+			.forEach(entry -> res.put( fileUriToPath(entry.getKey()), entry.getValue() ));
+		return res;
+	}
+	private HashMap<String, String> fileContents = new HashMap<>();
+
+	@Override
+	public void didOpen(DidOpenTextDocumentParams params) {
+		String text = params.getTextDocument().getText();
+		String uri = params.getTextDocument().getUri();
+		fileContents.put(uri, text);
+	}
+
+	@Override
+	public void didChange(DidChangeTextDocumentParams params) {
+		// https://raw.githubusercontent.com/eclipse/eclipse.jdt.ls/0ed1bf259b3edb4f184804a9df14c95ef468d4e9/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
+		String text = params.getContentChanges().get(0).getText();
+		String uri = params.getTextDocument().getUri();
+		fileContents.put(uri, text);
+
+		cachedCompModuleForFileUri = null;
+		cachedCompModuleForFileUri_Uri = null;
+	}
+	
+	@Override
+	public void didSave(DidSaveTextDocumentParams params) {
+		String text = params.getText();
+		
+		if(text != null) {
+			String uri = params.getTextDocument().getUri();
+			fileContents.put(uri, text);
+
+			cachedCompModuleForFileUri = null;
+			cachedCompModuleForFileUri_Uri = null;
+		}
+	}
+	
+	// WorkspaceService methods
+	@Override
+	public void didClose(DidCloseTextDocumentParams params) {
+		fileContents.remove(params.getTextDocument().getUri());
+	}
+
+	@Override
+	public CompletableFuture<List<? extends SymbolInformation>> symbol(WorkspaceSymbolParams params) {
+		
+		if(this.directory == null)
+			return CompletableFuture.completedFuture(null);
+		
+		List<SymbolInformation> res = folderSymbols(this.directory).stream().filter(symbol -> {
+			return symbol.getName().toLowerCase().contains(params.getQuery().toLowerCase());
+		}).collect(Collectors.toList());
+
+		return CompletableFuture.completedFuture(res);
+	}
+
+	@Override
+	public void didChangeConfiguration(DidChangeConfigurationParams params) {
+	}
+
+	@Override
+	public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
+	}
+
+	static String removeThisPrefix(String name) {
+		if (name.startsWith("this/")) {
+			return name.substring("this/".length());
+		}
+		return name;
+	}
+
+	private PublishDiagnosticsParams toPublishDiagnosticsParams(Err err) {
+		return toPublishDiagnosticsParamsList(Arrays.asList(err)).get(0);
+	}
+	
+	private List<PublishDiagnosticsParams> toPublishDiagnosticsParamsList(List<Err> errors){
+		
+		Map<String, List<Err>> map =
+				errors.stream()
+				.collect(Collectors.groupingBy( warning -> warning.pos.filename));
+		return map.entrySet().stream().map(entry -> {
+
+			List<Diagnostic> diags= entry.getValue().stream().map(err -> {
+				Diagnostic diag = newDiagnostic(err.msg, createRangeFromPos(err.pos));
+				diag.setSeverity(err instanceof ErrorWarning ? 
+						DiagnosticSeverity.Warning : DiagnosticSeverity.Error);
+				
+				return diag;
+			}).collect(Collectors.toList());
+
+			return newPublishDiagnosticsParams(filePathToUri(entry.getKey()), diags);
+		}).collect(Collectors.toList());		
+	}
+	
+	private String newInstance;
+	private VizGUI viz;
+	// edu.mit.csail.sdg.alloy4whole.SimpleGUI.doRun(Integer)
+	private void doRun(String fileURI, Integer commandIndex) {
+		CompModule module = CompUtil.parseOneModule(fileContents.get(fileURI));
+		ConstList<edu.mit.csail.sdg.ast.Command> commands = module.getAllCommands();
+
+		final int index = commandIndex;
+		if (WorkerEngine.isBusy())
+			return;
+
+		if (commands == null)
+			return;
+		if (commands.size() == 0 && index != -2 && index != -3) {
+			// log.logRed("There are no commands to execute.\n\n");
+			return;
+		}
+		int i = index;
+		if (i >= commands.size())
+			i = commands.size() - 1;
+		// SimpleCallback1 cb = new SimpleCallback1(this, null, log,
+		// VerbosityPref.get().ordinal(), latestAlloyVersionName, latestAlloyVersion);
+		SimpleTask1 task = new SimpleTask1();
+		A4Options opt = new A4Options();
+		opt.tempDirectory = SimpleGUI.alloyHome(null) + fs + "tmp";
+		opt.solverDirectory = SimpleGUI.alloyHome(null) + fs + "binary";
+		opt.recordKodkod = RecordKodkod.get();
+		opt.noOverflow = NoOverflow.get();
+		opt.unrolls = Version.experimental ? Unrolls.get() : (-1);
+		opt.skolemDepth = SkolemDepth.get();
+		opt.coreMinimization = CoreMinimization.get();
+		opt.inferPartialInstance = InferPartialInstance.get();
+		opt.coreGranularity = CoreGranularity.get();
+
+		log("cwd :" + Paths.get("").toAbsolutePath());
+
+		String fileNameDecoded;
+		try {
+			fileNameDecoded = URIUtil.toFile(new URI(fileURI)).getPath();
+			
+		} catch (Exception ex) {
+			System.err.println("failed to parse uri");
+			return;
+		}
+		log("fileNameDecoded:" + fileNameDecoded);
+
+		opt.originalFilename = fileNameDecoded;// new File(decodeUrl(uri)).getPath();// Util.canon(decodeUrl(uri));
+		opt.solver = Solver.get();
+		task.bundleIndex = i;
+		task.bundleWarningNonFatal = WarningNonfatal.get();
+		// task.map = text.takeSnapshot();
+		task.options = opt.dup();
+		task.resolutionMode = (Version.experimental && ImplicitThis.get()) ? 2 : 1;
+		task.tempdir = SimpleGUI.maketemp(null);
+
+		try {
+			int newmem = SubMemory.get(), newstack = SubStack.get();
+			if (newmem != subMemoryNow || newstack != subStackNow)
+				WorkerEngine.stop();
+
+			WorkerCallback cb = getWorkerCallback();
+
+			log("actually running the task");
+			// if (AlloyCore.isDebug() && VerbosityPref.get() == Verbosity.FULLDEBUG)
+			//WorkerEngine.runLocally(task, cb);
+			// else
+			WorkerEngine.run(task, newmem, newstack, SimpleGUI.alloyHome(null) + fs + "binary", "", cb);
+			subMemoryNow = newmem;
+			subStackNow = newstack;
+		} catch (Throwable ex) {
+			WorkerEngine.stop();
+			System.err.println("Fatal Error: Solver failed due to unknown reason. exception: \n" + ex.toString());
+			// log.logBold("Fatal Error: Solver failed due to unknown reason.\n" + "One
+			// possible cause is that, in the Options menu, your specified\n" + "memory size
+			// is larger than the amount allowed by your OS.\n" + "Also, please make sure
+			// \"java\" is in your program path.\n");
+			// log.logDivider();
+			// log.flush();
+			doStop(2);
+		}
+		return;
+	}
+
+	private WorkerCallback getVizWorkerCallback() {
+		return new WorkerCallback() {
+			
+			@Override
+			public void fail() {
+				AlloyLSMessage alloyMsg = new AlloyLSMessage(AlloyLSMessageType.RunCompleted, "failure");
+				client.showExecutionOutput(alloyMsg);
+				
+			}
+			
+			@Override
+			public void done() {
+				viz.loadXML(newInstance, true);
+				
+			}
+			
+			@Override
+			public void callback(Object msg) {
+				Either<List<AlloyLSMessage>, Err> alloyMsgOrWarning = solverCallbackMsgToAlloyMsg(msg);
+
+				if (alloyMsgOrWarning.isLeft()) {
+					for(AlloyLSMessage alloyMsg :alloyMsgOrWarning.getLeft()) {
+						if (alloyMsg.message != null && !alloyMsg.message.isEmpty())
+							//client.showExecutionOutput(alloyMsg);
+							client.logMessage(newMessageParams(alloyMsg.message, MessageType.Log));
+					}
+
+				} else {
+					//warnings.add(alloyMsgOrWarning.getRight());
+				}
+				
+			}
+		};
+	}
+	private WorkerCallback getWorkerCallback() {
+		return new WorkerCallback() {
+			List<Err> warnings = new ArrayList<>();
+
+			@Override
+			public void callback(Object msg) {
+
+				// MessageParams messageParams= new MessageParams();
+				// messageParams.setMessage(solverCallbackMsgToString(msg));
+				// client.showMessage(messageParams);
+//					if(messageParams.getMessage() != null && !messageParams.getMessage().isEmpty())
+//						client.showAlloyOutput(messageParams);
+
+				Either<List<AlloyLSMessage>, Err> alloyMsgOrWarning =
+						solverCallbackMsgToAlloyMsg(msg);
+
+				if (alloyMsgOrWarning.isLeft()) {
+					for(AlloyLSMessage alloyMsg :alloyMsgOrWarning.getLeft()) {
+						if (alloyMsg.message != null && !alloyMsg.message.isEmpty())
+							client.showExecutionOutput(alloyMsg);
+					}
+
+				} else {
+					Err err = alloyMsgOrWarning.getRight();
+
+					if(Pos.UNKNOWN.equals(err.pos) || err.pos == null){
+						AlloyLSMessage errMsg = new AlloyLSMessage(AlloyLSMessageType.Warning, err.msg + "\n");
+						errMsg.bold = true;
+						client.showExecutionOutput(errMsg);
+					}
+					warnings.add(alloyMsgOrWarning.getRight());
+				}
+			}
+
+			@Override
+			public void done() {
+				// MessageParams messageParams= new MessageParams();
+				// messageParams.setMessage("done");
+				// client.showMessage(messageParams);
+				// client.showAlloyOutput(messageParams);
+				if(warnings.size() > 0)
+					client.showExecutionOutput(
+						new AlloyLSMessage(AlloyLSMessageType.RunResult, "There were errors/warnings!"));
+				
+				client.showExecutionOutput(new AlloyLSMessage(AlloyLSMessageType.RunCompleted, ""));
+				
+				publishDiagnostics();
+			}
+
+			@Override
+			public void fail() {
+				AlloyLSMessage alloyMsg = new AlloyLSMessage(AlloyLSMessageType.RunCompleted, "failure");
+				client.showExecutionOutput(alloyMsg);
+				publishDiagnostics();
+			}
+			
+			void publishDiagnostics() {
+				
+				//cleaning previously reported diagnostics
+				if(fileUrisOfLastPublishedDiagnostics != null)
+					fileUrisOfLastPublishedDiagnostics.stream().forEach(item -> {
+						PublishDiagnosticsParams diagnostics = new PublishDiagnosticsParams();
+						diagnostics.setUri(item);
+						client.publishDiagnostics(diagnostics );
+				});
+
+				List<PublishDiagnosticsParams> diagnosticsParamsList = 
+						toPublishDiagnosticsParamsList(warnings);
+				
+				diagnosticsParamsList
+					.forEach(diagsParams -> client.publishDiagnostics(diagsParams));
+
+				fileUrisOfLastPublishedDiagnostics.clear();
+				fileUrisOfLastPublishedDiagnostics.addAll( 
+						diagnosticsParamsList.stream()
+						.map( item -> item.getUri())
+						.collect(Collectors.toList()));
+
+			}
+
+		};
+	}
+
+	// edu.mit.csail.sdg.alloy4whole.SimpleReporter.SimpleCallback1.callback(Object)
+	public Either<List<AlloyLSMessage>, Err> solverCallbackMsgToAlloyMsg(Object msg) {
+		StringBuilder span = new StringBuilder();
+		AlloyLSMessage alloyMsg = new AlloyLSMessage(
+				AlloyLSMessageType.RunInProgress, null);
+		
+		List<AlloyLSMessage> resMsgs = new ArrayList<>();
+		resMsgs.add(alloyMsg);
+		
+		final int verbosity = 0;
+		if (msg == null) {
+			span.append("Done\n");
+		} else if (msg instanceof String) {
+			span.append(((String) msg).trim() + "\n");
+		} else if (msg instanceof Throwable) {
+			for (Throwable ex = (Throwable) msg; ex != null; ex = ex.getCause()) {
+				if (ex instanceof OutOfMemoryError) {
+					span.append("\nFatal Error: the solver ran out of memory!\n"
+							+ "Try simplifying your model or reducing the scope,\n"
+							+ "or increase memory under the Options menu.\n");
+				}
+				if (ex instanceof StackOverflowError) {
+					span.append("\nFatal Error: the solver ran out of stack space!\n"
+							+ "Try simplifying your model or reducing the scope,\n"
+							+ "or increase stack under the Options menu.\n");
+				}
+			}
+			if (msg instanceof Err) {
+				log("Err msg from solver: " + msg.toString());
+				Err ex = (Err) msg;
+				String text = "fatal";
+				boolean fatal = false;
+				if (ex instanceof ErrorSyntax)
+					text = "syntax";
+				else if (ex instanceof ErrorType)
+					text = "type";
+				else
+					fatal = true;
+				if (ex.pos == Pos.UNKNOWN)
+					span.append("A " + text + " error has occurred:  ");
+				else
+					span.append("A " + text + " error has occurred:  " + "POS: " + ex.pos.x + " " + ex.pos.y + " "
+							+ ex.pos.x2 + " " + ex.pos.y2 + " " + ex.pos.filename);
+				// if (verbosity > 2) {
+				// 	span.log("(see the ");
+				// 	span.logLink("stacktrace", "MSG: " + ex.dump());
+				// 	span.log(")\n");
+				// } else {
+				// 	span.log("\n");
+				// }
+				span.append(ex.msg.trim()); // logIndented
+				return Either.forRight(ex);
+				//span.append("\n");
+				// if (fatal && latestVersion > Version.buildNumber())
+				// 	span.logBold("\nNote: You are running Alloy build#" + Version.buildNumber() + ",\nbut the most recent is Alloy build#" + latestVersion + ":\n( version " + latestName + " )\nPlease try to upgrade to the newest version," + "\nas the problem may have been fixed already.\n");
+
+				// if (!fatal)
+				// 	gui.doVisualize("POS: " + ex.pos.x + " " + ex.pos.y + " " + ex.pos.x2 + " " + ex.pos.y2 + " " + ex.pos.filename);
+			}
+			else /*if (msg instanceof Throwable)*/ {
+				log("exception msg from solver: " + msg.toString());
+				Throwable ex = (Throwable) msg;
+				span.append(ex.toString().trim() + "\n");
+				// span.flush();
+			}
+		 } else if ((msg instanceof Object[])) {
+			Object[] array = (Object[]) msg;
+			if (array[0].equals("pop")) {
+				// span.setLength(len2);
+				String x = (String) (array[1]);
+				span.append(x);
+				alloyMsg.replaceLast = true;
+				// if (viz != null && x.length() > 0)
+				// 	OurDialog.alert(x);
+			}
+			if (array[0].equals("declare")) {
+				//gui.doSetLatest((String) (array[1]));
+				newInstance = (String) (array[1]);
+				// ==========
+			}
+			if (array[0].equals("S2")) {
+           		// len3 = len2 = span.getLength();
+				span.append("" + array[1]);
+			}
+			if (array[0].equals("R3")) {
+           		//span.setLength(len3);
+				span.append("" + array[1]);
+			}
+			if (array[0].equals("link")) {
+				log("link message!!!");
+          		//span.logLink((String) (array[1]), (String) (array[2]));
+				span.append(array[1].toString());
+				alloyMsg.link = (String) array[2];
+				alloyMsg.messageType = AlloyLSMessageType.RunResult;
+
+			}
+			if (array[0].equals("bold")) {
+				span.append("" + array[1]);
+				alloyMsg.bold = true;
+				//alloyMsg.replaceLast = true;
+			}
+			if (array[0].equals("")) {
+				span.append("" + array[1]);
+			}
+			if (array[0].equals("scope") && verbosity > 0) {
+				span.append("   " + array[1]);
+			}
+			if (array[0].equals("bound") && verbosity > 1) {
+				span.append("   " + array[1]);
+			}
+			if (array[0].equals("resultCNF")) {
+				// results.add(null);
+				// span.setLength(len3);
+				// span.log(" File written to " + array[1] + "\n\n");
+			}
+			if (array[0].equals("debug") && verbosity > 2) {
+				span.append("   " + array[1] + "\n");
+				// len2 = len3 = span.getLength();
+			}
+			if (array[0].equals("translate")) {
+				span.append("   " + array[1]);
+				// len3 = span.getLength();
+				span.append("   Generating CNF...\n");
+			}
+			if (array[0].equals("solve")) {
+				// span.setLength(len3);
+				span.append("   " + array[1]);
+				// len3 = span.getLength();
+				span.append("   Solving...\n");
+			}
+			if (array[0].equals("warnings")) {
+				// if (warnings.size() == 0)
+				// 	span.setLength(len2);
+				// else if (warnings.size() > 1)
+				// 	span.logBold("Note: There were " + warnings.size() + " compilation warnings. Please scroll up to see them.\n\n");
+				// else
+				// 		span.append("Note: There was 1 compilation wrearning. Please scroll up to see
+				// 		them.\n\n");
+				// 		span.append("There were warnings!");
+				// if (warnings.size() > 0 && Boolean.FALSE.equals(array[1])) {
+				// 	Pos e = warnings.iterator().next().pos;
+				// 	gui.doVisualize("POS: " + e.x + " " + e.y + " " + e.x2 + " " + e.y2 + " " + e.filename);
+				// 	span.logBold("Warnings often indicate errors in the model.\n" + "Some warnings can affect the soundness of the analysis.\n" + "To proceed despite the warnings, go to the Options menu.\n");
+				// }
+			}
+			if (array[0].equals("warning")) {
+				ErrorWarning e = (ErrorWarning) (array[1]);
+				// if (!warnings.add(e))
+				// 	return;
+				Pos p = e.pos;
+           		// span.logLink("Warning #" + warnings.size(), "POS: " + p.x + " " + p.y + " " + p.x2 + " " + p.y2 + " " + p.filename);
+				span.append("Warning " + e.msg.trim());// #" + warnings.size(), "POS: " + p.x + " " + p.y + " " + p.x2 +
+														// " " + p.y2 + " " + p.filename);
+				return Either.forRight(e);
+				// span.log("\n");
+				// span.logIndented(e.msg.trim());
+				// span.log("\n\n");
+			}
+			if (array[0].equals("sat")) {
+				boolean chk = Boolean.TRUE.equals(array[1]);
+				int expects = (Integer) (array[2]);
+				String filename = (String) (array[3]), formula = (String) (array[4]);
+				// results.add(filename);
+				(new File(filename)).deleteOnExit();
+				// gui.doSetLatest(filename);
+				// span.setLength(len3);
+				span.append("   ");
+				// span.logLink(chk ? "Counterexample" : "Instance", "XML: " + filename);
+				span.append(chk ? "Counterexample" : "Instance");// , "XML: " + filename);
+				alloyMsg.link = "XML: " + filename;
+				alloyMsg.messageType = AlloyLSMessageType.RunResult;
+				alloyMsg.replaceLast = true;
+				alloyMsg.bold = true;
+				span.append(" found. ");
+				// span.logLink(chk ? "Assertion" : "Predicate", formula);
+				span.append(chk ? "Assertion" : "Predicate");// , formula);
+				span.append(chk ? " is invalid" : " is consistent");
+				if (expects == 0)
+					span.append(", contrary to expectation");
+				else if (expects == 1)
+					span.append(", as expected");
+				span.append(". ");
+				//span.append(". " + array[5] + "ms.\n\n");
+				alloyMsg.lineBreak = false;
+				resMsgs.add(new AlloyLSMessage(AlloyLSMessageType.RunResult, array[5] + "ms.\n\n"));
+			}
+			if (array[0].equals("metamodel")) {
+				// String outf = (String) (array[1]);
+				// span.setLength(len2);
+				// (new File(outf)).deleteOnExit();
+				// gui.doSetLatest(outf);
+				// span.logLink("Metamodel", "XML: " + outf);
+				// span.log(" successfully generated.\n\n");
+			}
+			if (array[0].equals("minimizing")) {
+              	boolean chk = Boolean.TRUE.equals(array[1]);
+				// int expects = (Integer) (array[2]);
+				// span.setLength(len3);
+				// span.log(chk ? "   No counterexample found." : "   No instance found.");
+              	span.append(chk ? "   No counterexample found. " : "   No instance found. ");
+				if (chk)
+					span.append(" Assertion may be valid");
+				else
+					span.append(" Predicate may be inconsistent");
+				// if (expects == 1)
+				// 	span.log(", contrary to expectation");
+				// else if (expects == 0)
+				// 	span.log(", as expected");
+				span.append(". " + array[4] + "ms.\n");
+	           	// span.logBold("   Minimizing the unsat core of " + array[3] + " entries...\n");
+			}
+			if (array[0].equals("unsat")) {
+				boolean chk = Boolean.TRUE.equals(array[1]);
+				int expects = (Integer) (array[2]);
+				String formula = (String) (array[4]);
+           		// span.setLength(len3);
+				alloyMsg.messageType = AlloyLSMessageType.RunResult;
+				alloyMsg.replaceLast = true;
+				alloyMsg.bold = true;
+				span.append(chk ? "   No counterexample found. " : "   No instance found. ");
+				span.append(chk ? "Assertion" : "Predicate");// , formula);
+				span.append(chk ? " may be valid" : " may be inconsistent");
+				if (expects == 1)
+					span.append(", contrary to expectation");
+				else if (expects == 0)
+					span.append(", as expected");
+				if (array.length == 5) {
+					span.append(". ");
+					alloyMsg.lineBreak = false;
+					resMsgs.add(new AlloyLSMessage(RunResult, array[3] + "ms.\n\n"));
+ 		            // span.flush();
+				} else {
+					String core = (String) (array[5]);
+					int mbefore = (Integer) (array[6]), mafter = (Integer) (array[7]);
+					span.append(". " + array[3] + "ms.\n");
+					if (core.length() == 0) {
+						// results.add("");
+						span.append("   No unsat core is available in this case. ");
+						
+						resMsgs.add(new AlloyLSMessage(RunResult, array[8] + "ms.\n\n"));
+						// span.flush();
+					} else {
+
+						// results.add(core);
+						(new File(core)).deleteOnExit();
+						span.append("   ");
+						//span.append("Core");// , core);
+						
+						AlloyLSMessage coreLinkMsg = new AlloyLSMessage(RunResult, "core");
+						coreLinkMsg.link = core;
+						resMsgs.add(coreLinkMsg);
+						
+						AlloyLSMessage nextMsg = new AlloyLSMessage(RunResult, null);
+						if (mbefore <= mafter)
+							nextMsg.message = (" contains " + mafter + " top-level formulas. " + array[8] + "ms.\n\n");
+						else
+							nextMsg.message = (" reduced from " + mbefore + " to " + mafter + " top-level formulas. "
+									+ array[8] + "ms.\n\n");
+						resMsgs.add(nextMsg);
+					}
+				}
+			}
+		}
+		alloyMsg.message = span.toString();
+		return Either.forLeft(resMsgs);
+	}
+
+	   /**
+     * This method stops the current run or check (how==0 means DONE, how==1 means
+     * FAIL, how==2 means STOP).
+     */
+    void doStop(Integer how) {
+        int h = how;
+        if (h != 0) {
+            if (h == 2 && WorkerEngine.isBusy()) {
+                WorkerEngine.stop();
+                //log.logBold("\nSolving Stopped.\n");
+                //log.logDivider();
+            }
+            WorkerEngine.stop();
+        }
+		// runmenu.setEnabled(true);
+		// runbutton.setVisible(true);
+		// showbutton.setEnabled(true);
+		// stopbutton.setVisible(false);
+		// if (latestAutoInstance.length() > 0) {
+		// 	String f = latestAutoInstance;
+		// 	latestAutoInstance = "";
+		// 	if (subrunningTask == 2)
+		// 		viz.loadXML(f, true);
+		// 	else if (AutoVisualize.get() || subrunningTask == 1)
+		// 		doVisualize("XML: " + f);
+		// }
+    }
+
+	// edu.mit.csail.sdg.alloy4whole.SimpleGUI.doVisualize(String) for handling
+	// instance visualization links
+
+	private void doVisualize(String arg) {
+		log("doVisualize() called with " + arg);
+		if (arg.startsWith("CORE: ")) { // CORE: filename
+			String filename = Util.canon(arg.substring(6));
+			Pair<Set<Pos>, Set<Pos>> hCore;
+			// Set<Pos> lCore;
+			InputStream is = null;
+			ObjectInputStream ois = null;
+			try {
+				is = new FileInputStream(filename);
+				ois = new ObjectInputStream(is);
+				hCore = (Pair<Set<Pos>, Set<Pos>>) ois.readObject();
+				// lCore = (Set<Pos>) ois.readObject();
+				List<Err> errs = Stream.concat(
+						hCore.a.stream().map(pos -> new ErrorWarning(pos, "part of unsat core")),
+					    hCore.b.stream().map(pos -> new ErrorWarning(pos, "possibly part of unsat core")))
+						.collect(Collectors.toList());
+				
+				List<PublishDiagnosticsParams> publishDiags = this.toPublishDiagnosticsParamsList(errs);
+				
+				fileUrisOfLastPublishedDiagnostics.clear(); 
+				fileUrisOfLastPublishedDiagnostics.addAll( 
+						publishDiags.stream()
+						.map(PublishDiagnosticsParams::getUri)
+						.collect(Collectors.toList()));
+				
+				publishDiags.forEach(client::publishDiagnostics);
+				
+			} catch (Throwable ex) {
+				System.err.println("Error reading or parsing the core \"" + filename + "\"\n");
+				// return null;
+			} finally {
+				Util.close(ois);
+				Util.close(is);
+			}
+			
+			
+			
+			// text.clearShade();
+			// text.shade(hCore.b, subCoreColor, false);
+			// text.shade(hCore.a, coreColor, false);
+			// // shade again, because if not all files were open, some shadings
+			// // will have no effect
+			// text.shade(hCore.b, subCoreColor, false);
+			// text.shade(hCore.a, coreColor, false);
+		}
+		if (arg.startsWith("POS: ")) { // POS: x1 y1 x2 y2 filename
+			Scanner s = new Scanner(arg.substring(5));
+			int x1 = s.nextInt(), y1 = s.nextInt(), x2 = s.nextInt(), y2 = s.nextInt();
+			String f = s.nextLine();
+			if (f.length() > 0 && f.charAt(0) == ' ')
+				f = f.substring(1); // Get rid of the space after Y2
+			Pos p = new Pos(Util.canon(f), x1, y1, x2, y2);
+
+		}
+		if (arg.startsWith("CNF: ")) { // CNF: filename
+			String filename = Util.canon(arg.substring(5));
+			try {
+				String text = Util.readAll(filename);
+				OurDialog.showtext("Text Viewer", text);
+			} catch (IOException ex) {
+				System.err.println("Error reading the file \"" + filename + "\"\n");
+			}
+		}
+		if (arg.startsWith("XML: ")) { // XML: filename
+
+			// from SimpleGui
+			// VizGUI viz = new VizGUI(false, "", windowmenu2, enumerator, evaluator);
+			if(viz == null)
+				viz = new VizGUI(false, "", null, enumerator, evaluator, 1);
+			viz.loadXML(Util.canon(arg.substring(5)), false);
+		}
+	}
+	
+	/** This object performs solution enumeration. */
+    private final Computer enumerator = new Computer() {
+
+        @Override
+        public String compute(Object input) {
+            final String[] arg = (String[]) input;
+            //OurUtil.show(frame);
+            if (WorkerEngine.isBusy())
+                throw new RuntimeException("Alloy4 is currently executing a SAT solver command. Please wait until that command has finished.");
+            //SimpleCallback1 cb = new SimpleCallback1(SimpleGUI.this, viz, log, VerbosityPref.get().ordinal(), latestAlloyVersionName, latestAlloyVersion);
+            WorkerCallback cb = getVizWorkerCallback();
+            SimpleTask2 task = new SimpleTask2();
+            task.filename = arg[0];
+						task.index = Integer.valueOf(arg[1]);
+            try {
+                if (AlloyCore.isDebug())
+                    WorkerEngine.runLocally(task, cb);
+                else
+                    WorkerEngine.run(task, SubMemory.get(), SubStack.get(), SimpleGUI.alloyHome(null) + fs + "binary", "", cb);
+                // task.run(cb);
+            } catch (Throwable ex) {
+                WorkerEngine.stop();
+                System.err.println("Fatal Error: Solver failed due to unknown reason.\n" + "One possible cause is that, in the Options menu, your specified\n" + "memory size is larger than the amount allowed by your OS.\n" + "Also, please make sure \"java\" is in your program path.\n");
+                //log.logBold("Fatal Error: Solver failed due to unknown reason.\n" + "One possible cause is that, in the Options menu, your specified\n" + "memory size is larger than the amount allowed by your OS.\n" + "Also, please make sure \"java\" is in your program path.\n");
+                //log.logDivider();
+                //log.flush();
+                doStop(2);
+                return arg[0];
+            }
+           /* subrunningTask = 2;
+            runmenu.setEnabled(false);
+            runbutton.setVisible(false);
+            showbutton.setEnabled(false);
+            stopbutton.setVisible(true);*/
+            return arg[0];
+        }
+    };
+    
+
+    /** This object performs expression evaluation. */
+    private static Computer evaluator = new Computer() {
+
+        private String filename = null;
+
+        @Override
+        public final Object compute(final Object input) throws Exception {
+            if (input instanceof File) {
+                filename = ((File) input).getAbsolutePath();
+                return "";
+            }
+            if (!(input instanceof String[]))
+                return "";
+            final String[] strs = (String[]) input;
+            if (strs[0].trim().length() == 0)
+                return ""; // Empty line
+            Module root = null;
+            A4Solution ans = null;
+            try {
+                Map<String,String> fc = new LinkedHashMap<String,String>();
+                XMLNode x = new XMLNode(new File(filename));
+                if (!x.is("alloy"))
+                    throw new Exception();
+                String mainname = null;
+                for (XMLNode sub : x)
+                    if (sub.is("instance")) {
+                        mainname = sub.getAttribute("filename");
+                        break;
+                    }
+                if (mainname == null)
+                    throw new Exception();
+                for (XMLNode sub : x)
+                    if (sub.is("source")) {
+                        String name = sub.getAttribute("filename");
+                        String content = sub.getAttribute("content");
+                        fc.put(name, content);
+                    }
+                root = CompUtil.parseEverything_fromFile(A4Reporter.NOP, fc, mainname, (Version.experimental && ImplicitThis.get()) ? 2 : 1);
+                ans = A4SolutionReader.read(root.getAllReachableSigs(), x);
+                for (ExprVar a : ans.getAllAtoms()) {
+                    root.addGlobal(a.label, a);
+                }
+                for (ExprVar a : ans.getAllSkolems()) {
+                    root.addGlobal(a.label, a);
+                }
+            } catch (Throwable ex) {
+                throw new ErrorFatal("Failed to read or parse the XML file.");
+            }
+            try {
+                Expr e = CompUtil.parseOneExpression_fromString(root, strs[0]);
+                if (AlloyCore.isDebug() && VerbosityPref.get() == Verbosity.FULLDEBUG) {
+                    SimInstance simInst = SimpleGUI.convert(root, ans);
+                    if (simInst.wasOverflow())
+                        return simInst.visitThis(e).toString() + " (OF)";
+                }
+                return ans.eval(e, Integer.valueOf(strs[1])).toString();
+            } catch (HigherOrderDeclException ex) {
+                throw new ErrorType("Higher-order quantification is not allowed in the evaluator.");
+            }
+        }
+    };	
+	
+	static Pos getCurrentWordSelectionAsPos(String text, Pos pos){
+		int[] sel = getCurrentWordSelection(text, pos);
+		pos = Pos.toPos(text, sel[0], sel[1]);
+		return pos;
+	}
+
+    // from OurSyntaxWidget
+    static int[] getCurrentWordSelection(String text, Pos pos ) {
+
+    	int[] startEnd = pos.toStartEnd(text);
+        int selectionStart = startEnd[0];
+        int selectionEnd = startEnd[1];
+
+        if (!isValidSelection(text, selectionStart, selectionEnd))
+            return null;
+
+        while (isValidSelection(text, selectionStart - 1, selectionEnd) && inWord(text.charAt(selectionStart - 1)))
+            selectionStart--;
+
+        while (isValidSelection(text, selectionStart, selectionEnd + 1) && inWord(text.charAt(selectionEnd)))
+            selectionEnd++;
+
+        if (!isValidSelection(text, selectionStart, selectionEnd))
+            return null;
+        return new int[] {
+                          selectionStart, selectionEnd
+        };
+    }
+    
+    // from OurSyntaxWidget
+    static boolean isValidSelection(String text, int start, int end) {
+        return start >= 0 && start <= end && end >= start && end <= text.length();
+    }
+    
+    // from OurSyntaxWidget
+    private static boolean inWord(char c) {
+        return Character.isAlphabetic(c) || Character.isDigit(c) || Character.isIdentifierIgnorable(c) || Character.isJavaIdentifierPart(c) || c == '\'' || c == '"';
+    }
+
+    
+    private static void log(String s) {
+    	System.out.println("thread: " + Thread.currentThread().getId() + "| " + s);
+    }
+
+
+	static List<Expr> findAllReferences(CompModule module, Pos pos, boolean includeSelf){
+		
+		List<Expr> references = new ArrayList<Expr>();
+
+		if(module == null)
+			return references;
+		Expr expr = module.find(pos);
+		if(expr == null)
+			return references;
+		Expr referencedExpr = expr.referenced() != null ?  module.find(expr.referenced().pos()) : expr;
+
+
+		if(includeSelf)
+			references.add(referencedExpr);
+		module.visitExpressionsResilient(new VisitQueryOnce<Void>(){
+			@Override
+            public boolean visited(Expr expr) {
+                boolean visited = super.visited(expr);
+                if (visited)
+					return visited;
+			
+				if (expr.referenced() != null && expr.referenced().pos().equals(referencedExpr.pos)){
+					log("reference: " + expr.toString());
+					references.add(expr);
+				}
+				return visited;
+			}	
+		});
+		return references;
+	}
+
+	List<Pos> findAllReferencesGlobally(CompModule module, Pos pos, String rootDir, boolean includeSelf, boolean continueOnError)
+		throws Err {
+
+		List<Pos> references = new ArrayList<Pos>();
+
+		Expr expr = module.find(pos);
+
+		log("finding references to " + pos.toRangeString() + ", expr: " + expr);
+
+		if(expr == null)
+			return references;
+
+		if(expr.referenced() != null)
+			log("expr.referenced(): " + expr.referenced().toString());
+
+
+		Pos targetPos = expr.referenced() != null ? expr.referenced().pos() :  expr.pos;
+		log("targetPos: " + targetPos.toRangeString());
+
+		if(targetPos.equals(Pos.UNKNOWN))
+			return references;
+
+		if(includeSelf)
+			references.add(targetPos);
+		
+		for (File child: alloyFilesInDir(rootDir)){
+
+			String filePath = fileUriToPath(child.toURI().toString());
+			try{
+				CompModule childModule = getCompModuleForFileUri(child.toURI().toString()); 
+
+				childModule.visitExpressionsResilient(new VisitQueryOnce<Void>(){
+					@Override
+					public boolean visited(Expr expr) {
+						boolean visited = super.visited(expr);
+						if (visited)
+							return visited;
+					
+						if (expr.referenced() != null ){
+							Pos rpos = expr.referenced().pos();
+							if(rpos.equals(targetPos)){
+								log("reference: " + expr.toString() + "; to file: " + rpos.filename);
+								references.add(expr.pos);
+							}
+						}
+						return visited;
+					}	
+				});
+			}catch(Exception ex){
+				log("exception parsing" + child.toString() + ": " + ex.toString());
+				if(! continueOnError) throw ex;
+			}
+		}  
+		return references;
+	}
+
+	static List<File> alloyFilesInDir(String dir){
+		File[] directoryListing = new File(dir).listFiles();
+		return Arrays.stream(directoryListing)
+				.filter(child -> child.isFile()
+						&& (FilenameUtils.isExtension(child.getAbsolutePath(), new String[] { "als" }) || 
+							isAlloyMarkdownFile(child.getAbsolutePath())))
+				.collect(Collectors.toList());
+	}
+	
+	static boolean isAlloyMarkdownFile(String filename) {
+		if (!FilenameUtils.isExtension(filename, new String[] { "md" })) return false;
+		
+		try (BufferedReader br = new BufferedReader(new FileReader(filename))){
+			return "---".equals(br.readLine());
+		} catch(IOException ex) {
+			return false;
+		}
+	}
+	
+	static boolean isAlloyFile(String filename, String contents) {
+		if (FilenameUtils.isExtension(filename, new String[] { "als" })) return true;
+		
+		if(FilenameUtils.isExtension(filename, new String[] { "md" }) && contents.startsWith("---")) return true;
+		
+		return false;
+	}
+
+	
+}

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageServerUtil.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageServerUtil.java
@@ -1,0 +1,94 @@
+package edu.mit.csail.sdg.alloy4whole;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import edu.mit.csail.sdg.alloy4.Pos;
+import edu.mit.csail.sdg.alloy4.Util;
+
+public class AlloyLanguageServerUtil {
+	public static Pos positionToPos(Position position) {
+		return positionToPos(position, null);
+	}
+
+	public static Pos positionToPos(Position position, String fileName) {
+		return new Pos(fileName, position.getCharacter() + 1, position.getLine() + 1);
+	}
+
+	public static Location posToLocation(Pos pos){
+		Location res= new Location();
+		res.setRange(createRangeFromPos(pos));
+		res.setUri(filePathToUri(pos.filename));
+		return res;
+	}
+
+	public static org.eclipse.lsp4j.Position posToPosition(edu.mit.csail.sdg.alloy4.Pos pos) {
+		Position position = new Position();
+		position.setLine(pos.y - 1);
+		position.setCharacter(pos.x - 1);
+		return position;
+	}
+	public static Range createRange(Position start, Position end) {
+		Range res = new Range();
+		res.setStart(start);
+		res.setEnd(end);
+		return res;
+	}
+	public static Range createRangeFromPos(Pos pos) {
+		Range res = new Range();
+		res.setStart(posToPosition(pos));
+		
+		Position endPosition = new Position();
+		endPosition.setLine(pos.y2 - 1);
+		endPosition.setCharacter(pos.x2 - 1 + 1 /* end position appears to be exclusive in Range */);
+		
+		res.setEnd(endPosition);
+		return res;
+	}
+
+	public static String filePathToUri(String absolutePath) {
+		return Paths.get(absolutePath).toUri().toString();
+	}
+	
+	public static String fileUriToPath(String fileUri) {
+		try {
+			File file = new File(new URI(fileUri));
+			try {
+				return file.getCanonicalPath();
+			} catch (IOException ex) {
+				return file.getAbsolutePath();
+			}
+		} catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+
+	public static String filePathResolved(String filename) {
+		return filename.replace(Util.jarPrefix(), SimpleGUI.alloyHome(null) + fs);
+	}
+
+	/**
+	 * Return .getLeft() of the Either object, or throw .getRight()
+	 * @return .getLeft() of the Either object if it isLeft()
+	 * @throws TErr
+	 */
+	public static <TRes,TErr extends Exception> TRes getResult(Either<TRes,TErr> val) throws TErr{
+		if (val.isRight()) throw val.getRight();
+		return val.getLeft();
+	}
+
+	/**
+	 * The system-specific file separator (forward-slash on UNIX, back-slash on
+	 * Windows, etc.)
+	 */
+	public static final String fs = System.getProperty("file.separator");
+
+}

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyTools.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyTools.java
@@ -1,0 +1,9 @@
+package edu.mit.csail.sdg.alloy4whole;
+
+
+public class AlloyTools {
+
+    public static void main(String args[]) throws Exception {
+        SimpleGUI.main(args);
+    }
+}

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/DemoFileSystem.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/DemoFileSystem.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import edu.mit.csail.sdg.alloy4.Err;
+import edu.mit.csail.sdg.alloy4.Pos;
 import edu.mit.csail.sdg.ast.Attr;
 import edu.mit.csail.sdg.ast.Command;
 import edu.mit.csail.sdg.ast.Decl;
@@ -54,14 +55,14 @@ public class DemoFileSystem {
     }
 
     PrimSig makeSig(PrimSig parent, String name, boolean isAbstract, boolean isOne) throws Err {
-        PrimSig ans = new PrimSig(name, parent, (isAbstract ? Attr.ABSTRACT : null), (isOne ? Attr.ONE : null));
+        PrimSig ans = new PrimSig(null, name, Pos.UNKNOWN, parent, (isAbstract ? Attr.ABSTRACT : null), (isOne ? Attr.ONE : null));
         sigs.add(ans);
         return ans;
     }
 
     void runFor3(Expr expr) throws Err {
         A4Options opt = new A4Options();
-        Command cmd = new Command(false, 3, 3, 3, expr.and(fact));
+        Command cmd = new Command(false, 3, 3, 3, null, expr.and(fact));
         A4Solution sol = TranslateAlloyToKodkod.execute_command(NOP, sigs, cmd, opt);
         System.out.println(sol.toString().trim());
         if (sol.satisfiable()) {

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/ExampleUsingTheAPI.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/ExampleUsingTheAPI.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import edu.mit.csail.sdg.alloy4.Err;
+import edu.mit.csail.sdg.alloy4.Pos;
 import edu.mit.csail.sdg.alloy4.Util;
 import edu.mit.csail.sdg.ast.Attr;
 import edu.mit.csail.sdg.ast.Command;
@@ -54,10 +55,10 @@ public final class ExampleUsingTheAPI {
         PrimSig B = new PrimSig("B");
 
         // one sig A1 extends A {}
-        PrimSig A1 = new PrimSig("A1", A, Attr.ONE);
+        PrimSig A1 = new PrimSig(null, "A1", Pos.UNKNOWN, A, Attr.ONE);
 
         // one sig A2 extends A {}
-        PrimSig A2 = new PrimSig("A2", A, Attr.ONE);
+        PrimSig A2 = new PrimSig(null, "A2", Pos.UNKNOWN, A, Attr.ONE);
 
         // A { f: B lone->lone B }
         Expr f = A.addField("f", B.lone_arrow_lone(B));
@@ -71,13 +72,13 @@ public final class ExampleUsingTheAPI {
         // If you want "setOf", you need: A.addField(null, "g", B.setOf())
 
         // pred someG { some g }
-        Func someG = new Func(null, "SomeG", null, null, g.some());
+        Func someG = new Func(null, Pos.UNKNOWN, "SomeG", null, null, g.some());
 
         // pred atMostThree[x:univ, y:univ] { #(x+y) >= 3 }
         Decl x = UNIV.oneOf("x");
         Decl y = UNIV.oneOf("y");
         Expr body = x.get().plus(y.get()).cardinality().lte(ExprConstant.makeNUMBER(3));
-        Func atMost3 = new Func(null, "atMost3", Util.asList(x, y), null, body);
+        Func atMost3 = new Func(null, Pos.UNKNOWN, "atMost3", Util.asList(x, y), null, body);
 
         List<Sig> sigs = Arrays.asList(new Sig[] {
                                                   A, B, A1, A2
@@ -85,14 +86,14 @@ public final class ExampleUsingTheAPI {
 
         // run { some A && atMostThree[B,B] } for 3 but 3 int, 3 seq
         Expr expr1 = A.some().and(atMost3.call(B, B));
-        Command cmd1 = new Command(false, 3, 3, 3, expr1);
+        Command cmd1 = new Command(false, 3, 3, 3, null, expr1);
         A4Solution sol1 = TranslateAlloyToKodkod.execute_command(NOP, sigs, cmd1, opt);
         System.out.println("[Solution1]:");
         System.out.println(sol1.toString());
 
         // run { some f && SomeG[] } for 3 but 2 int, 1 seq, 5 A, exactly 6 B
         Expr expr2 = f.some().and(someG.call());
-        Command cmd2 = new Command(false, 3, 2, 1, expr2);
+        Command cmd2 = new Command(false, 3, 2, 1, null, expr2);
         cmd2 = cmd2.change(A, false, 1);
         cmd2 = cmd2.change(B, true, 1);
         A4Solution sol2 = TranslateAlloyToKodkod.execute_command(NOP, sigs, cmd2, opt);

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/Lsp4jUtil.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/Lsp4jUtil.java
@@ -1,0 +1,52 @@
+package edu.mit.csail.sdg.alloy4whole;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.lsp4j.*;
+
+public class Lsp4jUtil {
+	public static PublishDiagnosticsParams newPublishDiagnosticsParams(String uri, List<Diagnostic> diagnostics) {
+		PublishDiagnosticsParams diagnosticsParams = new PublishDiagnosticsParams();
+		diagnosticsParams.setDiagnostics(diagnostics);
+		diagnosticsParams.setUri(uri);
+		return diagnosticsParams;
+	}
+
+	public static Diagnostic newDiagnostic(String message, Range range) {
+		Diagnostic res = new Diagnostic();
+		res.setMessage(message);
+		res.setRange(range);
+		return res;
+	}
+
+	public static MessageParams newMessageParams(String message, MessageType type) {
+		MessageParams res = new MessageParams();
+		res.setMessage(message);
+		res.setType(type);
+		return res;
+	}
+
+	public static Location newLocation(Range range, String uri) {
+		Location location = new Location();
+		location.setRange(range);
+		location.setUri(uri);
+		return location;
+	}
+
+	public static SymbolInformation newSymbolInformation(String name, Location location, SymbolKind kind) {
+		SymbolInformation symbolInfo = new SymbolInformation();
+		symbolInfo.setLocation(location);
+		symbolInfo.setName(name);
+		symbolInfo.setKind(kind);
+		return symbolInfo;
+	}
+
+
+	public static int positionCompare(Position p1, Position p2){	
+		return p1.getLine() < p2.getLine() ? -1 : p1.getLine() > p2.getLine() ? 1 :
+			   p1.getCharacter() < p2.getCharacter() ? -1 :
+			   p1.getCharacter() > p2.getCharacter() ? 1 :
+			   0;
+	}
+}

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleCLI.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleCLI.java
@@ -235,9 +235,9 @@ public final class SimpleCLI {
                             x.b.toString(sb, 4);
                             rep.flush();
                         }
-                        for (Pair<String,Expr> x : m.getAllAssertions()) {
-                            sb.append("\nAssertion ").append(x.a).append("\n");
-                            x.b.toString(sb, 4);
+                        for (edu.mit.csail.sdg.ast.Assert x : m.getAllAssertions()) {
+                            sb.append("\nAssertion ").append(x.label).append("\n");
+                            x.expr.toString(sb, 4);
                             rep.flush();
                         }
                         if (m == world)

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleReporter.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleReporter.java
@@ -762,38 +762,40 @@ final class SimpleReporter extends A4Reporter {
                         rep.cb("", "   #" + (i + 1) + ": Unknown.\n");
                         continue;
                     }
+                    StringBuilder sb = new StringBuilder();
                     if (result.get(i).endsWith(".xml")) {
                         rep.cb("", "   #" + (i + 1) + ": ");
                         rep.cb("link", r.check ? "Counterexample found. " : "Instance found. ", "XML: " + result.get(i));
-                        rep.cb("", r.label + (r.check ? " is invalid" : " is consistent"));
+                        sb.append(r.label + (r.check ? " is invalid" : " is consistent"));
                         if (r.expects == 0)
-                            rep.cb("", ", contrary to expectation");
+                        	sb.append(", contrary to expectation");
                         else if (r.expects == 1)
-                            rep.cb("", ", as expected");
+                        	sb.append(", as expected");
                     } else if (result.get(i).endsWith(".core")) {
                         rep.cb("", "   #" + (i + 1) + ": ");
                         rep.cb("link", r.check ? "No counterexample found. " : "No instance found. ", "CORE: " + result.get(i));
-                        rep.cb("", r.label + (r.check ? " may be valid" : " may be inconsistent"));
+                        sb.append(r.label + (r.check ? " may be valid" : " may be inconsistent"));
                         if (r.expects == 1)
-                            rep.cb("", ", contrary to expectation");
+                        	sb.append(", contrary to expectation");
                         else if (r.expects == 0)
-                            rep.cb("", ", as expected");
+                        	sb.append(", as expected");
                     } else {
                         if (r.check)
-                            rep.cb("", "   #" + (i + 1) + ": No counterexample found. " + r.label + " may be valid");
+                        	sb.append("   #" + (i + 1) + ": No counterexample found. " + r.label + " may be valid");
                         else
-                            rep.cb("", "   #" + (i + 1) + ": No instance found. " + r.label + " may be inconsistent");
+                        	sb.append("   #" + (i + 1) + ": No instance found. " + r.label + " may be inconsistent");
                         if (r.expects == 1)
-                            rep.cb("", ", contrary to expectation");
+                        	sb.append(", contrary to expectation");
                         else if (r.expects == 0)
-                            rep.cb("", ", as expected");
+                        	sb.append(", as expected");
                     }
-                    rep.cb("", ".\n");
+                    sb.append(".\n");
+                    rep.cb("", sb.toString());
                 }
                 rep.cb("", "\n");
             }
             if (rep.warn > 1)
-                rep.cb("bold", "Note: There were " + rep.warn + " compilation warnings. Please scroll up to see them.\n");
+                rep.cb("bold", "Note: There were " + rep.warn + " compilation warnings.\n");
             if (rep.warn == 1)
                 rep.cb("bold", "Note: There was 1 compilation warning. Please scroll up to see it.\n");
 

--- a/org.alloytools.alloy.core/parser/Alloy.cup
+++ b/org.alloytools.alloy.core/parser/Alloy.cup
@@ -26,6 +26,7 @@ package edu.mit.csail.sdg.parser;
 import java.util.Stack;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.TreeSet;
 import java.util.Map;
 import java.util.LinkedHashMap;
@@ -298,7 +299,7 @@ parser code {:
         if (content==null && loaded!=null) content = loaded.get(filename);
         if (content==null) content = Util.readAll(filename);
         if (loaded!=null) loaded.put(filename,content);
-        content = MarkdownHandler.strip(content);
+        if (content.startsWith("---") || filename.toLowerCase(Locale.ROOT).endsWith(".md")) content = MarkdownHandler.strip(content);
         content = Util.convertLineBreak(content);
         isr = new StringReader(content);
         CompFilter s = new CompFilter(u, seenDollar, filename, lineOffset, new BufferedReader(isr));
@@ -378,9 +379,9 @@ action code {:
       	  }
         }
         if (n!=null)
-          parser.alloymodule.addCommand(follow, p, n, o.label.equals("c"), overall, bitwidth, maxseq, mintime, maxtime, expects, s, x);
+          parser.alloymodule.addCommand(follow, p, n, o, overall, bitwidth, maxseq, mintime, maxtime, expects, s, x);
         else
-          parser.alloymodule.addCommand(follow, p, e, o.label.equals("c"), overall, bitwidth, maxseq, mintime, maxtime, expects, s, x);
+          parser.alloymodule.addCommand(follow, p, e, o, overall, bitwidth, maxseq, mintime, maxtime, expects, s, x);
     }
     private Expr t(Pos pos, Pos oldClosing, Expr left, Expr right, Pos close) throws Err {
       if (right instanceof ExprVar) {
@@ -648,9 +649,9 @@ Spec ::= Spec Vis:p ENUM:o Name:a LBRACE         RBRACE:c                      {
 Spec ::= Spec       FACT:o          Super:e {:         parser.alloymodule.addFact      (o , ""       , e); :};
 Spec ::= Spec       FACT:o   Name:n Super:e {: nod(n); parser.alloymodule.addFact      (o , n.label  , e); :};
 Spec ::= Spec       FACT:o   STR:n  Super:e {:         parser.alloymodule.addFact      (o , n.string , e); :};
-Spec ::= Spec       ASSERT:o        Super:e {:         parser.alloymodule.addAssertion (o , ""       , e); :};
-Spec ::= Spec       ASSERT:o Name:n Super:e {: nod(n); parser.alloymodule.addAssertion (o , n.label  , e); :};
-Spec ::= Spec       ASSERT:o STR:n  Super:e {:         parser.alloymodule.addAssertion (o , n.string , e); :};
+Spec ::= Spec       ASSERT:o        Super:e {:         parser.alloymodule.addAssertion (o , null , ""       , e); :};
+Spec ::= Spec       ASSERT:o Name:n Super:e {: nod(n); parser.alloymodule.addAssertion (o , n.pos, n.label  , e); :};
+Spec ::= Spec       ASSERT:o STR:n  Super:e {:         parser.alloymodule.addAssertion (o , null,  n.string , e); :};
 Spec ::= Spec Sig             ;
 Spec ::= Spec Function        ;
 Spec ::= Spec Predicate       ;
@@ -673,8 +674,8 @@ Command ::= Command IMPLIES CommandPrefix:o        Name:n   Scope:s  Expects:c {
 Expects    ::=                 {: RESULT=null; :};
 Expects    ::= EXPECT NUMBER:a {: RESULT=a;    :};
 
-Scope      ::= FOR NUMBER:a                  {: RESULT=new ArrayList<CommandScope>(); RESULT.add(new CommandScope(a.pos, new PrimSig("univ", AttrType.WHERE.make(a.pos)), true, a.num, a.num, 1)); :};
-Scope      ::= FOR NUMBER:a BUT Typescopes:b {: RESULT=b;                                  b.add(new CommandScope(a.pos, new PrimSig("univ", AttrType.WHERE.make(a.pos)), true, a.num, a.num, 1)); :};
+Scope      ::= FOR NUMBER:a                  {: RESULT=new ArrayList<CommandScope>(); RESULT.add(new CommandScope(a.pos, Pos.UNKNOWN, new PrimSig("univ", AttrType.WHERE.make(a.pos)), true, a.num, a.num, 1)); :};
+Scope      ::= FOR NUMBER:a BUT Typescopes:b {: RESULT=b;                                  b.add(new CommandScope(a.pos, Pos.UNKNOWN, new PrimSig("univ", AttrType.WHERE.make(a.pos)), true, a.num, a.num, 1)); :};
 Scope      ::= FOR              Typescopes:b {: RESULT=b;                                                                                                                     :};
 Scope      ::=                               {: RESULT=new ArrayList<CommandScope>();                                                                                         :};
 
@@ -683,7 +684,7 @@ Typescopes ::= Typescopes:a COMMA Typescope:b {: RESULT=a; a.add(b);            
 
 Typescope  ::= TypeNumber:a Name:b  {:
    nod(b);
-   RESULT = new CommandScope(a.pos.merge(b.pos), new PrimSig(b.label, AttrType.WHERE.make(a.pos.merge(b.pos))), a.isExact, a.startingScope, a.endingScope, a.increment);
+   RESULT = new CommandScope(a.pos.merge(b.pos), b.pos, new PrimSig(b.label, AttrType.WHERE.make(a.pos.merge(b.pos))), a.isExact, a.startingScope, a.endingScope, a.increment);
 :};
 
 //[AM]: INT -> SIGINT
@@ -691,31 +692,31 @@ Typescope ::= TypeNumber:a SIGINT:b  {:
    Pos p = a.pos.merge(b);
    if (a.endingScope>a.startingScope) throw new ErrorSyntax(p, "Cannot specify a growing scope for \"Int\"");
    if (a.isExact) throw new ErrorSyntax(p, "The exactly keyword is redundant here since the integer bitwidth must be exact.");
-   RESULT = new CommandScope(p, new PrimSig("int", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.startingScope, 1);
+   RESULT = new CommandScope(p, b, new PrimSig("int", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.startingScope, 1);
 :};
 
 Typescope ::= TypeNumber:a INT:b  {: 
    Pos p = a.pos.merge(b);
    if (a.endingScope>a.startingScope) throw new ErrorSyntax(p, "Cannot specify a growing scope for \"Int\"");
    if (a.isExact) throw new ErrorSyntax(p, "The exactly keyword is redundant here since the integer bitwidth must be exact.");
-   RESULT = new CommandScope(p, new PrimSig("int", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.startingScope, 1);
+   RESULT = new CommandScope(p, b, new PrimSig("int", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.startingScope, 1);
 :};
 
 Typescope ::= TypeNumber:a SEQ:b  {:
    Pos p = a.pos.merge(b);
    if (a.endingScope>a.startingScope) throw new ErrorSyntax(p, "Cannot specify a growing scope for \"seq\"");
    if (a.isExact) throw new ErrorSyntax(p, "The exactly keyword is redundant here since the number of sequence index has to be exact.");
-   RESULT = new CommandScope(p, new PrimSig("seq", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.startingScope, 1);
+   RESULT = new CommandScope(p, b, new PrimSig("seq", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.startingScope, 1);
 :};
 
 Typescope  ::= TypeNumber:e UNIV:f    {: if (1==1) throw new ErrorSyntax(e.pos.merge(f), "You cannot set a scope on univ."); :};
 
-Typescope  ::= TypeNumber:a STRING:b  {: RESULT = new CommandScope(a.pos.merge(b), new PrimSig("String", AttrType.WHERE.make(a.pos.merge(b))), a.isExact, a.startingScope, a.endingScope, a.increment); :};
+Typescope  ::= TypeNumber:a STRING:b  {: RESULT = new CommandScope(a.pos.merge(b), b, new PrimSig("String", AttrType.WHERE.make(a.pos.merge(b))), a.isExact, a.startingScope, a.endingScope, a.increment); :};
 
 // [electrum] scope on Time
 Typescope  ::= TypeNumber:a TIME:b    {:
     Pos p = a.pos.merge(b);
-	RESULT = new CommandScope(p, new PrimSig("steps", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.endingScope, a.increment); 
+	RESULT = new CommandScope(p, Pos.UNKNOWN, new PrimSig("steps", AttrType.WHERE.make(p)), a.isExact, a.startingScope, a.endingScope, a.increment); 
 :};
 
 //[AM] Typescope  ::= TypeNumber:e SIGINT:f  {: if (1==1) throw new ErrorSyntax(e.pos.merge(f), "You can no longer set a scope on Int; the number of Int atoms is always exactly equal to 2^(integer bitwidth).\n"); :};
@@ -723,39 +724,39 @@ Typescope  ::= TypeNumber:a TIME:b    {:
 Typescope  ::= TypeNumber:e NONE:f    {: if (1==1) throw new ErrorSyntax(e.pos.merge(f), "You cannot set a scope on none."); :};
 
 // [electrum] distinguish between "n" and "n..n", the latter become exact; open ended scopes "n.."
-TypeNumber ::= EXACTLY:e NUMBER:a                                  {:                                                                                RESULT = new CommandScope(    e.merge(a.pos), Sig.NONE, true,           a.num, a.num,             1    ); :};
-TypeNumber ::= EXACTLY:e NUMBER:a DOT DOT NUMBER:b                 {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e.merge(b.pos), Sig.NONE, true,           a.num, b.num,             1    ); :};
-TypeNumber ::= EXACTLY:e NUMBER:a DOT DOT                          {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e             , Sig.NONE, true,           a.num, Integer.MAX_VALUE, 1    ); :};
-TypeNumber ::= EXACTLY:e NUMBER:a DOT DOT NUMBER:b COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e.merge(i.pos), Sig.NONE, true,           a.num, b.num,             i.num); :};
-TypeNumber ::= EXACTLY:e NUMBER:a                  COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e.merge(i.pos), Sig.NONE, true,           a.num, Integer.MAX_VALUE, i.num); :};
-TypeNumber ::=           NUMBER:a                                  {:                                                                                RESULT = new CommandScope(a.pos             , Sig.NONE, false,          a.num, a.num,             1    ); :};
-TypeNumber ::=           NUMBER:a DOT DOT NUMBER:b                 {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos.merge(b.pos), Sig.NONE, a.num == b.num, a.num, b.num,             1    ); :}; 
-TypeNumber ::=           NUMBER:a DOT DOT                          {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos             , Sig.NONE, false,          a.num, Integer.MAX_VALUE, 1    ); :}; 
-TypeNumber ::=           NUMBER:a DOT DOT NUMBER:b COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos.merge(i.pos), Sig.NONE, a.num == b.num, a.num, b.num,             i.num); :};
-TypeNumber ::=           NUMBER:a                  COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos.merge(i.pos), Sig.NONE, false,          a.num, Integer.MAX_VALUE, i.num); :};
+TypeNumber ::= EXACTLY:e NUMBER:a                                  {:                                                                                RESULT = new CommandScope(    e.merge(a.pos), Pos.UNKNOWN, Sig.NONE, true,           a.num, a.num,             1    ); :};
+TypeNumber ::= EXACTLY:e NUMBER:a DOT DOT NUMBER:b                 {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e.merge(b.pos), Pos.UNKNOWN, Sig.NONE, true,           a.num, b.num,             1    ); :};
+TypeNumber ::= EXACTLY:e NUMBER:a DOT DOT                          {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e             , Pos.UNKNOWN, Sig.NONE, true,           a.num, Integer.MAX_VALUE, 1    ); :};
+TypeNumber ::= EXACTLY:e NUMBER:a DOT DOT NUMBER:b COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e.merge(i.pos), Pos.UNKNOWN, Sig.NONE, true,           a.num, b.num,             i.num); :};
+TypeNumber ::= EXACTLY:e NUMBER:a                  COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(    e.merge(i.pos), Pos.UNKNOWN, Sig.NONE, true,           a.num, Integer.MAX_VALUE, i.num); :};
+TypeNumber ::=           NUMBER:a                                  {:                                                                                RESULT = new CommandScope(a.pos             , Pos.UNKNOWN, Sig.NONE, false,          a.num, a.num,             1    ); :};
+TypeNumber ::=           NUMBER:a DOT DOT NUMBER:b                 {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos.merge(b.pos), Pos.UNKNOWN, Sig.NONE, a.num == b.num, a.num, b.num,             1    ); :}; 
+TypeNumber ::=           NUMBER:a DOT DOT                          {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos             , Pos.UNKNOWN, Sig.NONE, false,          a.num, Integer.MAX_VALUE, 1    ); :}; 
+TypeNumber ::=           NUMBER:a DOT DOT NUMBER:b COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos.merge(i.pos), Pos.UNKNOWN, Sig.NONE, a.num == b.num, a.num, b.num,             i.num); :};
+TypeNumber ::=           NUMBER:a                  COLON NUMBER:i  {: if (!Version.experimental) throw new ErrorSyntax(a.pos, "Syntax error here."); RESULT = new CommandScope(a.pos.merge(i.pos), Pos.UNKNOWN, Sig.NONE, false,          a.num, Integer.MAX_VALUE, i.num); :};
 
-Macro ::= Vis:p LET:o              Name:n LPAREN   Names:d RPAREN   MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.label, d     , v); :};
-Macro ::= Vis:p LET:o              Name:n LPAREN           RPAREN   MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.label, null  , v); :};
-Macro ::= Vis:p LET:o              Name:n LBRACKET Names:d RBRACKET MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.label, d     , v); :};
-Macro ::= Vis:p LET:o              Name:n LBRACKET         RBRACKET MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.label, null  , v); :};
-Macro ::= Vis:p LET:o              Name:n                           MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.label, null  , v); :};
+Macro ::= Vis:p LET:o              Name:n LPAREN   Names:d RPAREN   MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.pos, n.label, d     , v); :};
+Macro ::= Vis:p LET:o              Name:n LPAREN           RPAREN   MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.pos, n.label, null  , v); :};
+Macro ::= Vis:p LET:o              Name:n LBRACKET Names:d RBRACKET MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.pos, n.label, d     , v); :};
+Macro ::= Vis:p LET:o              Name:n LBRACKET         RBRACKET MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.pos, n.label, null  , v); :};
+Macro ::= Vis:p LET:o              Name:n                           MacroBody:v {: nod(n); parser.alloymodule.addMacro(o.merge(v.span()), p, n.pos, n.label, null  , v); :};
 
 MacroBody ::= Super:a       {: RESULT=a; :};
 MacroBody ::= EQUALS Expr:a {: RESULT=a; :};
 
-Function ::= Vis:p FUN:o              Name:n LPAREN   Decls:d RPAREN   COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, null, d    , mult(r), v); :};
-Function ::= Vis:p FUN:o              Name:n LBRACKET Decls:d RBRACKET COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, null, d    , mult(r), v); :};
-Function ::= Vis:p FUN:o              Name:n                           COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, null, null , mult(r), v); :};
-Function ::= Vis:p FUN:o SigRef:f DOT Name:n LPAREN   Decls:d RPAREN   COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, f   , d    , mult(r), v); :};
-Function ::= Vis:p FUN:o SigRef:f DOT Name:n LBRACKET Decls:d RBRACKET COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, f   , d    , mult(r), v); :};
-Function ::= Vis:p FUN:o SigRef:f DOT Name:n                           COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, f   , null , mult(r), v); :};
+Function ::= Vis:p FUN:o              Name:n LPAREN   Decls:d RPAREN   COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, null, d    , mult(r), v); :};
+Function ::= Vis:p FUN:o              Name:n LBRACKET Decls:d RBRACKET COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, null, d    , mult(r), v); :};
+Function ::= Vis:p FUN:o              Name:n                           COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, null, null , mult(r), v); :};
+Function ::= Vis:p FUN:o SigRef:f DOT Name:n LPAREN   Decls:d RPAREN   COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, f   , d    , mult(r), v); :};
+Function ::= Vis:p FUN:o SigRef:f DOT Name:n LBRACKET Decls:d RBRACKET COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, f   , d    , mult(r), v); :};
+Function ::= Vis:p FUN:o SigRef:f DOT Name:n                           COLON Expr:r Super:v {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, f   , null , mult(r), v); :};
 
-Predicate ::= Vis:p PRED:o              Name:n LPAREN   Decls:d RPAREN   Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, null, d    , null, v); :};
-Predicate ::= Vis:p PRED:o              Name:n LBRACKET Decls:d RBRACKET Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, null, d    , null, v); :};
-Predicate ::= Vis:p PRED:o              Name:n                           Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, null, null , null, v); :};
-Predicate ::= Vis:p PRED:o SigRef:f DOT Name:n LPAREN   Decls:d RPAREN   Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, f   , d    , null, v); :};
-Predicate ::= Vis:p PRED:o SigRef:f DOT Name:n LBRACKET Decls:d RBRACKET Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, f   , d    , null, v); :};
-Predicate ::= Vis:p PRED:o SigRef:f DOT Name:n                           Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n.label, f   , null , null, v); :};
+Predicate ::= Vis:p PRED:o              Name:n LPAREN   Decls:d RPAREN   Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, null, d    , null, v); :};
+Predicate ::= Vis:p PRED:o              Name:n LBRACKET Decls:d RBRACKET Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, null, d    , null, v); :};
+Predicate ::= Vis:p PRED:o              Name:n                           Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, null, null , null, v); :};
+Predicate ::= Vis:p PRED:o SigRef:f DOT Name:n LPAREN   Decls:d RPAREN   Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, f   , d    , null, v); :};
+Predicate ::= Vis:p PRED:o SigRef:f DOT Name:n LBRACKET Decls:d RBRACKET Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, f   , d    , null, v); :};
+Predicate ::= Vis:p PRED:o SigRef:f DOT Name:n                           Super:v             {: nod(n); parser.alloymodule.addFunc(o.merge(v.span()), p, n, f   , null , null, v); :};
 
 Vis ::=           {: RESULT=null; :};
 Vis ::= PRIVATE:p {: RESULT=p;    :};
@@ -765,7 +766,7 @@ Sig ::= SigQuals:a Names:b SigIn:c LBRACE Decls:d RBRACE:o SuperOpt:e
    if (e==null) e = ExprConstant.Op.TRUE.make(o, 0);
    ExprVar cc = (c!=null && c.size()>0) ? c.remove(c.size()-1) : null;
    for(ExprVar bb:b) {
-      parser.alloymodule.addSig(bb.label, cc, c, d, e,
+      parser.alloymodule.addSig(bb.pos, bb.label, cc, c, d, e,
          AttrType.WHERE   .makenull(bb.pos.merge(e==null ? o : e.span())),
          AttrType.ABSTRACT.makenull(a.get(0)),
          AttrType.LONE    .makenull(a.get(1)),

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/Pos.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/Pos.java
@@ -102,9 +102,9 @@ public final class Pos implements Serializable {
      * @param that - the other position object
      */
     public Pos merge(Pos that) {
-        if (that == null || that == UNKNOWN || that == this)
+        if (that == null || that.equals(UNKNOWN) || that == this)
             return this;
-        if (this == UNKNOWN)
+        if (this.equals(UNKNOWN))
             return that;
         int x = this.x, y = this.y, x2 = that.x2, y2 = that.y2;
         if (that.y < y || (that.y == y && that.x < x)) {
@@ -178,6 +178,11 @@ public final class Pos implements Serializable {
             return "line " + y + ", column " + x + ", filename=" + filename;
     }
 
+    public String toRangeString() {
+        String filePart = filename.length() == 0 ? "" : ", filename=" + filename;
+        return "line " + y + ", column " + x + " to line " + y2 + ", column " + x2 + filePart;
+    }
+
     int start() {
         return y * 500 + x;
     }
@@ -194,6 +199,10 @@ public final class Pos implements Serializable {
         int anchor = pos.start();
         int ourStart = start();
         int ourEnd = end();
+
+        if(!filename.equals(pos.filename) && !"".equals(pos.filename))
+            return false;
+            
         if (ourStart > anchor)
             return false;
 
@@ -307,5 +316,9 @@ public final class Pos implements Serializable {
 
     public boolean sameFile(Pos pos) {
         return this.filename.equals(pos.filename);
+    }
+
+    public Pos withFilename(String filename){
+        return new Pos(filename, x, y, x2, y2);
     }
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/WorkerEngine.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/WorkerEngine.java
@@ -27,6 +27,8 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.lang.reflect.Field;
+import java.util.Locale;
 
 import org.alloytools.alloy.core.AlloyCore;
 
@@ -365,6 +367,24 @@ public final class WorkerEngine {
                 }
             });
             latest_manager.start();
+
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+
+                @Override
+                public void run() {
+                    if (!System.getProperty("os.name").toLowerCase(Locale.US).startsWith("windows"))
+                        try {  //needed to stop all child processes (electrod)
+                            Field f = latest_sub.getClass().getDeclaredField("pid");
+                            f.setAccessible(true);
+                            Runtime.getRuntime().exec("kill -SIGTERM " + f.get(latest_sub));
+                        } catch (Exception e) {
+                            // TODO Auto-generated catch block
+                            e.printStackTrace();
+                        }
+                    else
+                        latest_sub.destroy();
+                }
+            });
         }
     }
 

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Assert.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Assert.java
@@ -1,0 +1,64 @@
+package edu.mit.csail.sdg.ast;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import edu.mit.csail.sdg.alloy4.Err;
+import edu.mit.csail.sdg.alloy4.ErrorWarning;
+import edu.mit.csail.sdg.alloy4.Pos;
+
+public final class Assert extends Expr implements Clause {
+    public final Expr expr;
+    public final Pos labelPos;
+    public final String label;
+    
+    public Assert(Pos pos, Pos labelPos, String label, Expr expr) {
+        super(pos, Type.FORMULA);
+        this.expr = expr;
+        this.labelPos = labelPos;
+        this.label = label;
+    }
+
+    @Override
+    public String explain() {
+        return "assert " + label;
+    }
+
+    @Override
+    public void toString(StringBuilder out, int indent) {
+        if (indent < 0) {
+            out.append(label);
+        } else {
+            for (int i = 0; i < indent; i++) {
+                out.append(' ');
+            }
+            out.append( "assert ").append(label).append('\n');
+        }
+    }
+
+    @Override
+    public <T> T accept(VisitReturn<T> visitor) throws Err {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public Expr resolve(Type t, Collection<ErrorWarning> warnings) {
+        return this;
+    }
+
+    @Override
+    public int getDepth() {
+        return 1;
+    }
+
+    @Override
+    public String getHTML() {
+        return "<b>assert</b> " + label;
+    }
+
+    @Override
+    public List< ? extends Browsable> getSubnodes() {
+        return Arrays.asList(expr);
+    }
+}

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Clause.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Clause.java
@@ -22,4 +22,25 @@ public interface Clause {
      * @return a string formatted like a set
      */
     String explain();
+
+    public final class Custom implements Clause{
+        final Pos pos;
+        final String explanation;
+
+        public Custom(Pos pos, String explanation) {
+            this.pos = pos;
+            this.explanation = explanation;
+        }
+
+        @Override
+        public Pos pos() {
+            return pos;
+        }
+
+        @Override
+        public String explain() {
+            return explanation;
+        }
+
+    }
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/CommandScope.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/CommandScope.java
@@ -38,6 +38,10 @@ public class CommandScope {
     public final Pos     pos;
 
     /**
+     * The position of the sig reference
+     */
+    public final Pos sigPos;
+    /**
      * The sig whose scope is being given by this CommandScope object.
      */
     public final Sig     sig;
@@ -69,7 +73,7 @@ public class CommandScope {
      * @throws ErrorSyntax if scope is less than zero
      */
     public CommandScope(Sig sig, boolean isExact, int scope) throws ErrorSyntax {
-        this(null, sig, isExact, scope, scope, 1);
+        this(null, null, sig, isExact, scope, scope, 1);
     }
 
     /**
@@ -87,7 +91,7 @@ public class CommandScope {
      * @throws ErrorSyntax if endingScope is less than startingScope
      * @throws ErrorSyntax if increment is less than one
      */
-    public CommandScope(Pos pos, Sig sig, boolean isExact, int startingScope, int endingScope, int increment) throws ErrorSyntax {
+    public CommandScope(Pos pos, Pos sigPos, Sig sig, boolean isExact, int startingScope, int endingScope, int increment) throws ErrorSyntax {
         if (pos == null)
             pos = Pos.UNKNOWN;
         if (sig == null)
@@ -104,12 +108,18 @@ public class CommandScope {
             throw new ErrorSyntax(pos, "Sig " + sig + "'s increment value cannot be " + increment + ".\nThe increment must be 1 or greater.");
         this.pos = pos;
         this.sig = sig;
+        this.sigPos = sigPos;
         this.isExact = isExact;
         this.startingScope = startingScope;
         this.endingScope = endingScope;
         this.increment = increment;
     }
 
+    Expr sigRef = null;
+    public Expr sigRef(){
+        if(sigRef == null) sigRef =  ExprUnary.Op.NOOP.make(sigPos, sig, null, 0);
+        return sigRef;
+    }
     /** {@inheritDoc} */
     @Override
     public String toString() {

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Expr.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Expr.java
@@ -1180,10 +1180,6 @@ public abstract class Expr extends Browsable {
      * <p>
      * this must be a formula
      */
-    public final Expr after() {
-        return ExprUnary.Op.AFTER.make(span(), this);
-    }
-
     /**
      * Returns the formula (before this)
      * <p>
@@ -1198,10 +1194,6 @@ public abstract class Expr extends Browsable {
      * <p>
      * this must be a formula
      */
-    public final Expr historically() {
-        return ExprUnary.Op.HISTORICALLY.make(span(), this);
-    }
-
     /**
      * Returns the formula (once this)
      * <p>

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/ExprCall.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/ExprCall.java
@@ -31,6 +31,7 @@ import edu.mit.csail.sdg.alloy4.JoinableList;
 import edu.mit.csail.sdg.alloy4.Pos;
 import edu.mit.csail.sdg.alloy4.Util;
 import edu.mit.csail.sdg.ast.Sig.Field;
+import edu.mit.csail.sdg.parser.Macro;
 
 /**
  * Immutable; represents a call.
@@ -264,6 +265,21 @@ public final class ExprCall extends Expr {
         @Override
         public Type visit(Sig x) {
             return x.type;
+        }
+
+        @Override
+        public Type visit(Func x) throws Err {
+            return x.type;
+        }
+
+        @Override
+        public Type visit(Assert x) throws Err {
+            return x.type;
+        }
+
+        @Override
+        public Type visit(Macro x) throws Err {
+            return x.type();
         }
 
         @Override

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Func.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Func.java
@@ -18,13 +18,16 @@ package edu.mit.csail.sdg.ast;
 import static edu.mit.csail.sdg.alloy4.TableView.clean;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 import edu.mit.csail.sdg.alloy4.ConstList;
 import edu.mit.csail.sdg.alloy4.Err;
 import edu.mit.csail.sdg.alloy4.ErrorSyntax;
 import edu.mit.csail.sdg.alloy4.ErrorType;
+import edu.mit.csail.sdg.alloy4.ErrorWarning;
 import edu.mit.csail.sdg.alloy4.Pos;
 import edu.mit.csail.sdg.alloy4.Util;
 
@@ -40,7 +43,7 @@ import edu.mit.csail.sdg.alloy4.Util;
  * predicate/function call
  */
 
-public final class Func extends Browsable implements Clause {
+public final class Func extends Expr implements Clause {
 
     /**
      * The location in the original file where this predicate/function is declared;
@@ -58,6 +61,11 @@ public final class Func extends Browsable implements Clause {
      * The label of this predicate/function; it does not need to be unique.
      */
     public final String          label;
+
+    /**
+     * The position of the label
+     */
+    public final Pos             labelPos;
 
     /**
      * True if this is a predicate; false if this is a function.
@@ -133,8 +141,8 @@ public final class Func extends Browsable implements Clause {
      * @throws ErrorSyntax if this function's return type declaration contains a
      *             predicate/function call
      */
-    public Func(Pos pos, String label, List<Decl> decls, Expr returnDecl, Expr body) throws Err {
-        this(pos, null, label, decls, returnDecl, body);
+    public Func(Pos pos, Pos labelPos, String label, List<Decl> decls, Expr returnDecl, Expr body) throws Err {
+        this(pos, null, labelPos, label, decls, returnDecl, body);
     }
 
     /**
@@ -167,12 +175,14 @@ public final class Func extends Browsable implements Clause {
      * @throws ErrorSyntax if this function's return type declaration contains a
      *             predicate/function call
      */
-    public Func(Pos pos, Pos isPrivate, String label, List<Decl> decls, Expr returnDecl, Expr body) throws Err {
+    public Func(Pos pos, Pos isPrivate, Pos labelPos, String label, List<Decl> decls, Expr returnDecl, Expr body) throws Err {
+        super(pos, Type.FORMULA);
         if (pos == null)
             pos = Pos.UNKNOWN;
         this.pos = pos;
         this.isPrivate = isPrivate;
         this.label = (label == null ? "" : label);
+        this.labelPos = labelPos;
         this.isPred = (returnDecl == null);
         if (returnDecl == null)
             returnDecl = ExprConstant.FALSE;
@@ -254,12 +264,6 @@ public final class Func extends Browsable implements Clause {
 
     /** {@inheritDoc} */
     @Override
-    public final Pos pos() {
-        return pos;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public final Pos span() {
         return pos;
     }
@@ -270,6 +274,12 @@ public final class Func extends Browsable implements Clause {
         return (isPred ? "<b>pred</b> " : "<b>fun</b> ") + label;
     }
 
+    ExprVar labelExpr = null;
+    public Expr labelExpr(){
+        if(labelExpr == null)
+            labelExpr = ExprVar.make(labelPos, label);
+        return labelExpr;
+    } 
     /** {@inheritDoc} */
     @Override
     public List< ? extends Browsable> getSubnodes() {
@@ -284,8 +294,7 @@ public final class Func extends Browsable implements Clause {
         return ans;
     }
 
-    @Override
-    public String explain() {
+    public String explainOld() {
         if (clean(label).contains("run$")) {
             return null;
         }
@@ -322,6 +331,56 @@ public final class Func extends Browsable implements Clause {
         }
 
         return sb.toString();
+    }
+
+    @Override
+    public String explain() {
+        StringBuilder sb = new StringBuilder();
+        if (isPred)
+            sb.append("pred ");
+        else
+            sb.append("fun ");
+
+        sb.append(clean(label));
+
+        if (decls.size() > 0 ) {
+            sb.append(" [\n");
+            sb.append(decls.stream()
+                      .flatMap(decl -> decl.names.stream().map(e -> " " + e + " : " + decl.expr.type))
+                      .collect(Collectors.joining(",\n")));
+            sb.append("\n]");
+        }
+        if (!isPred) {
+            sb.append(" ⟶ ").append(returnDecl.type.toString());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void toString(StringBuilder out, int indent) {
+        if (indent < 0) {
+            out.append("(").append(label).append(" <: ").append(label).append(")");
+        } else {
+            for (int i = 0; i < indent; i++) {
+                out.append(' ');
+            }
+            out.append( isPred? "pred " : "field ").append(label).append('\n');
+        }
+    }
+
+    @Override
+    public <T> T accept(VisitReturn<T> visitor) throws Err {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public Expr resolve(Type t, Collection<ErrorWarning> warnings) {
+        return this;
+    }
+
+    @Override
+    public int getDepth() {
+        return 1;
     }
 
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Module.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/Module.java
@@ -79,7 +79,7 @@ public interface Module extends Clause {
     /**
      * Return an unmodifiable list of all assertions in this module.
      */
-    public ConstList<Pair<String,Expr>> getAllAssertions();
+    public ConstList<Assert> getAllAssertions();
 
     /**
      * Return an unmodifiable list of all facts in this module.
@@ -110,7 +110,7 @@ public interface Module extends Clause {
     public JFrame showAsTree(Listener listener);
 
     /**
-     * Parse one expression by starting fromt this module as the root module.
+     * Parse one expression by starting from this module as the root module.
      */
     public Expr parseOneExpressionFromString(String input) throws Err, FileNotFoundException, IOException;
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/VisitQuery.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/VisitQuery.java
@@ -17,6 +17,7 @@ package edu.mit.csail.sdg.ast;
 
 import edu.mit.csail.sdg.alloy4.Err;
 import edu.mit.csail.sdg.ast.Sig.Field;
+import edu.mit.csail.sdg.parser.Macro;
 
 /**
  * This abstract class implements a Query visitor that walks over an Expr and
@@ -146,6 +147,21 @@ public abstract class VisitQuery<T> extends VisitReturn<T> {
      */
     @Override
     public T visit(Sig x) throws Err {
+        return null;
+    }
+
+    @Override
+    public T visit(Func x) throws Err {
+        return null;
+    }
+
+    @Override
+    public T visit(Assert x) throws Err {
+        return null;
+    }
+
+    @Override
+    public T visit(Macro x) throws Err {
         return null;
     }
 

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/VisitQueryOnce.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/VisitQueryOnce.java
@@ -4,6 +4,7 @@ import java.util.IdentityHashMap;
 
 import edu.mit.csail.sdg.alloy4.Err;
 import edu.mit.csail.sdg.ast.Sig.Field;
+import edu.mit.csail.sdg.parser.Macro;
 
 /**
  * Acts like VisitQuery but never traverses a node more than once.
@@ -144,4 +145,27 @@ public class VisitQueryOnce<T> extends VisitQuery<T> {
         return visited.put(x, x) != null;
     }
 
+    @Override
+    public T visit(Func x) throws Err {
+        if (visited(x))
+            return null;
+        else
+            return super.visit(x);    
+    }
+    
+    @Override
+    public T visit(Assert x) throws Err {
+        if (visited(x))
+            return null;
+        else
+            return super.visit(x);
+    }
+
+    @Override
+    public T visit(Macro x) throws Err {
+        if (visited(x))
+            return null;
+        else
+            return super.visit(x);
+    }
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/VisitReturn.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/ast/VisitReturn.java
@@ -17,6 +17,7 @@ package edu.mit.csail.sdg.ast;
 
 import edu.mit.csail.sdg.alloy4.Err;
 import edu.mit.csail.sdg.ast.Sig.Field;
+import edu.mit.csail.sdg.parser.Macro;
 
 /**
  * This abstract class defines what a Return Visitor's interface needs to be.
@@ -81,4 +82,13 @@ public abstract class VisitReturn<T> {
 
     /** Visits a Field node. */
     public abstract T visit(Field x) throws Err;
+
+    /** Visits a Func node. */
+    public abstract T visit(Func x) throws Err;
+
+    /** Visists an Assert node. */
+    public abstract T visit(Assert x) throws Err;
+
+    /** Visits a Macro node. */
+    public abstract T visit(Macro macro) throws Err;
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/CompModule.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/CompModule.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import edu.mit.csail.sdg.alloy4.A4Reporter;
 import edu.mit.csail.sdg.alloy4.ConstList;
@@ -56,6 +57,7 @@ import edu.mit.csail.sdg.alloy4.Pos;
 import edu.mit.csail.sdg.alloy4.SafeList;
 import edu.mit.csail.sdg.alloy4.Util;
 import edu.mit.csail.sdg.alloy4.Version;
+import edu.mit.csail.sdg.ast.Assert;
 import edu.mit.csail.sdg.ast.Attr;
 import edu.mit.csail.sdg.ast.Browsable;
 import edu.mit.csail.sdg.ast.Clause;
@@ -76,6 +78,7 @@ import edu.mit.csail.sdg.ast.ExprLet;
 import edu.mit.csail.sdg.ast.ExprList;
 import edu.mit.csail.sdg.ast.ExprQt;
 import edu.mit.csail.sdg.ast.ExprUnary;
+import edu.mit.csail.sdg.ast.ExprUnary.Op;
 import edu.mit.csail.sdg.ast.ExprVar;
 import edu.mit.csail.sdg.ast.Func;
 import edu.mit.csail.sdg.ast.Module;
@@ -243,7 +246,7 @@ public final class CompModule extends Browsable implements Module {
     private final Map<String,Macro>           macros      = new LinkedHashMap<String,Macro>();
 
     /** Each assertion name is mapped to its Expr. */
-    private final Map<String,Expr>            asserts     = new LinkedHashMap<String,Expr>();
+    private final Map<String,Assert>            asserts     = new LinkedHashMap<String,Assert>();
 
     /**
      * The list of facts; each fact is either an untypechecked Exp or a typechecked
@@ -384,7 +387,7 @@ public final class CompModule extends Browsable implements Module {
                 match = rootmodule.globals.get(name);
             if (match != null) {
                 if (match instanceof Macro)
-                    return ((Macro) match).changePos(pos);
+                    return (match);//.changePos(pos);
                 match = ExprUnary.Op.NOOP.make(pos, match);
                 return ExprChoice.make(isIntsNotUsed, pos, asList(match), asList(name));
             }
@@ -486,9 +489,14 @@ public final class CompModule extends Browsable implements Module {
         public Expr visit(ExprBadJoin x) throws Err {
             Expr left = visitThis(x.left);
             Expr right = visitThis(x.right);
+            Expr rightInner = ignoreNoops(right);
             // If it's a macro invocation, instantiate it
-            if (right instanceof Macro)
-                return ((Macro) right).addArg(left).instantiate(this, warns);
+            if (rightInner instanceof Macro){
+                Expr instantiated = ((Macro) rightInner).addArg(left).instantiate(this, warns);
+                Expr res = ExprUnary.Op.NOOP.make(right.pos, instantiated);
+                res.setReferenced(right.referenced());
+                return res;
+            }
             // check to see if it is the special builtin function "Int[]"
             if (left.type().is_int() && right.isSame(Sig.SIGINT))
                 return left; // [AM] .cast2sigint();
@@ -499,6 +507,15 @@ public final class CompModule extends Browsable implements Module {
             return process(x.pos, x.closingBracket, right.pos, ((ExprChoice) right).choices, ((ExprChoice) right).reasons, left);
         }
 
+        public static Expr ignoreNoops(Expr e){
+            if (e instanceof ExprUnary){
+                ExprUnary eu = (ExprUnary) e;
+                if( eu.op == Op.NOOP){
+                    return ignoreNoops(eu.sub);
+                }
+            }
+            return e;
+        }
         /** {@inheritDoc} */
         @Override
         public Expr visit(ExprBinary x) throws Err {
@@ -506,8 +523,13 @@ public final class CompModule extends Browsable implements Module {
             Expr right = visitThis(x.right);
             if (x.op == ExprBinary.Op.JOIN) {
                 // If it's a macro invocation, instantiate it
-                if (right instanceof Macro)
-                    return ((Macro) right).addArg(left).instantiate(this, warns);
+                Expr rightInner = ignoreNoops(right);
+                if (rightInner instanceof Macro){
+                    Expr instantiated = ((Macro) rightInner).addArg(left).instantiate(this, warns);
+                    Expr res = ExprUnary.Op.NOOP.make(right.pos, instantiated);
+                    res.setReferenced(right.referenced());
+                    return res;
+                }
                 // check to see if it is the special builtin function "Int[]"
                 if (left.type().is_int() && right.isSame(Sig.SIGINT))
                     return left; // [AM] .cast2sigint();
@@ -632,20 +654,9 @@ public final class CompModule extends Browsable implements Module {
             if (obj instanceof Macro) {
                 Macro macro = ((Macro) obj).copy();
                 Expr instantiated = macro.instantiate(this, warns);
-                instantiated.setReferenced(new Clause() {
-
-                    @Override
-                    public Pos pos() {
-                        return instantiated.pos;
-                    }
-
-                    @Override
-                    public String explain() {
-                        return instantiated.toString();
-                    }
-
-                });
-                return instantiated;
+                Expr res = ExprUnary.Op.NOOP.make(x.pos, instantiated);
+                res.setReferenced(new Clause.Custom(macro.pos, macro.toString()));
+                return res;
             } else
                 return obj;
         }
@@ -671,6 +682,21 @@ public final class CompModule extends Browsable implements Module {
         /** {@inheritDoc} */
         @Override
         public Expr visit(Sig x) {
+            return x;
+        }
+
+        @Override
+        public Expr visit(Func x) throws Err {
+            return x;
+        }
+
+        @Override
+        public Expr visit(Assert x) throws Err {
+            return x;
+        }
+
+        @Override
+        public Expr visit(Macro x) throws Err {
             return x;
         }
 
@@ -890,9 +916,9 @@ public final class CompModule extends Browsable implements Module {
         }
         if (asserts.size() > 0) {
             x = new ArrayList<Browsable>(asserts.size());
-            for (Map.Entry<String,Expr> e : asserts.entrySet()) {
-                Pos sp = e.getValue().span();
-                x.add(make(sp, sp, "<b>assert</b> " + e.getKey(), e.getValue()));
+            for (Map.Entry<String,Assert> e : asserts.entrySet()) {
+                Pos sp = e.getValue().expr.span();
+                x.add(make(sp, sp, "<b>assert</b> " + e.getKey(), e.getValue().expr));
             }
             ans.add(make("<b>" + x.size() + (x.size() > 1 ? " asserts</b>" : " assert</b>"), x));
         }
@@ -933,7 +959,7 @@ public final class CompModule extends Browsable implements Module {
     }
 
     /**
-     * Parse one expression by starting fromt this module as the root module.
+     * Parse one expression by starting from this module as the root module.
      */
     @Override
     public Expr parseOneExpressionFromString(String input) throws Err, FileNotFoundException, IOException {
@@ -993,7 +1019,7 @@ public final class CompModule extends Browsable implements Module {
             } else if (x instanceof Func) {
                 Func y = (Func) x;
                 msg.append(y.isPred ? "pred " : "fun ").append(y.label).append("\n" + "at ").append(y.pos.toShortString());
-            } else if (x instanceof Expr) {
+            } else if (x instanceof Assert) {
                 Expr y = (Expr) x;
                 msg.append("assertion at ").append(y.pos.toShortString());
             }
@@ -1095,7 +1121,7 @@ public final class CompModule extends Browsable implements Module {
                         ans.add(x);
             }
             if ((r & 2) != 0) {
-                Expr x = m.asserts.get(name);
+                Assert x = m.asserts.get(name);
                 if (x != null)
                     ans.add(x);
             }
@@ -1130,7 +1156,7 @@ public final class CompModule extends Browsable implements Module {
                             ans.add(x);
                 }
                 if ((r & 2) != 0) {
-                    Expr x = u.asserts.get(name);
+                    Assert x = u.asserts.get(name);
                     if (x != null)
                         ans.add(x);
                 }
@@ -1241,7 +1267,7 @@ public final class CompModule extends Browsable implements Module {
                 String name = expr.label;
                 dup(expr.span(), name, true);
                 if (path.length() == 0) {
-                    Sig newSig = addSig(name, null, null, null, null, WHERE.make(expr.span()));
+                    Sig newSig = addSig(null, name, null, null, null, null, WHERE.make(expr.span()));
                     if (nextIsExact)
                         exactSigs.add(newSig);
                 } else {
@@ -1447,7 +1473,8 @@ public final class CompModule extends Browsable implements Module {
         sigs.put(Sig.GHOST.label, Sig.GHOST);
     }
 
-    Sig addSig(String name, ExprVar par, List<ExprVar> parents, List<Decl> fields, Expr fact, Attr... attributes) throws Err {
+    Sig addSig(Pos namePos, String name, ExprVar par, List<ExprVar> parents, List<Decl> fields, Expr fact, Attr... attributes) throws Err {
+
         Sig obj;
         Pos pos = Pos.UNKNOWN.merge(WHERE.find(attributes));
         status = 3;
@@ -1469,14 +1496,15 @@ public final class CompModule extends Browsable implements Module {
         if (subset != null) {
             attributes = Util.append(attributes, SUBSET.makenull(subset));
             List<Sig> newParents = new ArrayList<Sig>(parents == null ? 0 : parents.size());
-            if (parents != null)
-                for (ExprVar p : parents)
-                    newParents.add(new PrimSig(p.label, WHERE.make(p.pos)));
-            obj = new SubsetSig(full, newParents, attributes);
+            if (parents == null) parents = Arrays.asList();
+            for (ExprVar p : parents)
+                newParents.add(new PrimSig(p.label, WHERE.make(p.pos)));
+            obj = new SubsetSig(namePos, full, parents.stream().map(p -> p.pos).collect(Collectors.toList()), newParents, attributes);
         } else {
             attributes = Util.append(attributes, SUBSIG.makenull(subsig));
             PrimSig newParent = (parents != null && parents.size() > 0) ? (new PrimSig(parents.get(0).label, WHERE.make(parents.get(0).pos))) : UNIV;
-            obj = new PrimSig(full, newParent, attributes);
+            Pos parentPos = (parents != null && parents.size() > 0) ? parents.get(0).pos : Pos.UNKNOWN;
+            obj = new PrimSig(namePos, full, parentPos, newParent, attributes);
         }
         sigs.put(name, obj);
         old2fields.put(obj, fields);
@@ -1491,9 +1519,9 @@ public final class CompModule extends Browsable implements Module {
         List<ExprVar> THESE = Arrays.asList(THIS);
         if (atoms == null || atoms.size() == 0)
             throw new ErrorSyntax(pos, "Enumeration must contain at least one name.");
-        addSig(name.label, null, null, null, null, WHERE.make(name.pos), ABSTRACT.make(name.pos), PRIVATE.makenull(priv), Attr.ENUM);
+        addSig(null, name.label, null, null, null, null, WHERE.make(name.pos), ABSTRACT.make(name.pos), PRIVATE.makenull(priv), Attr.ENUM);
         for (ExprVar a : atoms)
-            addSig(a.label, EXTENDS, THESE, null, null, WHERE.make(a.pos), ONE.make(a.pos), PRIVATE.makenull(priv));
+            addSig(null, a.label, EXTENDS, THESE, null, null, WHERE.make(a.pos), ONE.make(a.pos), PRIVATE.makenull(priv));
         int oldStatus = status;
         status = 0;
         try {
@@ -1520,18 +1548,20 @@ public final class CompModule extends Browsable implements Module {
             throw new ErrorType(pos, "Sig " + oldS + " is involved in a cyclic inheritance.");
         if (oldS instanceof SubsetSig) {
             List<Sig> parents = new ArrayList<Sig>();
-            for (Sig n : ((SubsetSig) oldS).parents) {
+            SubsetSig oldSS = (SubsetSig) oldS;
+            for (Sig n : oldSS.parents) {
                 Sig parentAST = u.getRawSIG(n.pos, n.label);
                 if (parentAST == null)
                     throw new ErrorSyntax(n.pos, "The sig \"" + n.label + "\" cannot be found.");
                 parents.add(resolveSig(res, topo, parentAST, warns));
             }
-            realSig = new SubsetSig(fullname, parents, oldS.attributes.toArray(new Attr[0]));
+            realSig = new SubsetSig(oldSS.pos, fullname, oldSS.parentRefPoss, parents, oldS.attributes.toArray(new Attr[0]));
             for (Sig n : parents)
                 if (n != UNIV && n.isVariable != null && realSig.isVariable == null)
                     warns.add(new ErrorWarning(realSig.isSubset, "Part of " + n.label + " is static.\n" + "Sig " + realSig.label + " is static but " + n.label + " is variable."));
         } else {
-            Sig sup = ((PrimSig) oldS).parent;
+            PrimSig oldSP = (PrimSig) oldS;
+            Sig sup = oldSP.parent;
             Sig parentAST = u.getRawSIG(sup.pos, sup.label);
             if (parentAST == null)
                 throw new ErrorSyntax(sup.pos, "The sig \"" + sup.label + "\" cannot be found.");
@@ -1539,7 +1569,7 @@ public final class CompModule extends Browsable implements Module {
             if (!(parent instanceof PrimSig))
                 throw new ErrorSyntax(sup.pos, "Cannot extend the subset signature \"" + parent + "\".\n" + "A signature can only extend a toplevel signature or a subsignature.");
             PrimSig p = (PrimSig) parent;
-            realSig = new PrimSig(fullname, p, oldS.attributes.toArray(new Attr[0]));
+            realSig = new PrimSig(oldSP.labelPos, fullname, oldSP.parentRefPos, p, oldS.attributes.toArray(new Attr[0]));
             if (parent != UNIV && parent.isVariable != null && realSig.isVariable == null)
                 warns.add(new ErrorWarning(realSig.isSubsig, "Part of " + parent.label + " is static.\n" + "Sig " + realSig.label + " is static but " + parent.label + " is variable."));
             if (parent != UNIV && parent.isVariable == null && realSig.isVariable != null)
@@ -1573,26 +1603,30 @@ public final class CompModule extends Browsable implements Module {
     // ============================================================================================================================//
 
     /** Add a MACRO declaration. */
-    void addMacro(Pos p, Pos isPrivate, String n, List<ExprVar> decls, Expr v) throws Err {
+    void addMacro(Pos p, Pos isPrivate, Pos labelPos, String label, List<ExprVar> decls, Expr v) throws Err {
         if (!Version.experimental)
             throw new ErrorSyntax(p, "LET declaration is allowed only inside a toplevel paragraph.");
         ConstList<ExprVar> ds = ConstList.make(decls);
         status = 3;
-        dup(p, n, false);
+        dup(p, label, false);
         for (int i = 0; i < ds.size(); i++)
             for (int j = i + 1; j < ds.size(); j++)
                 if (ds.get(i).label.equals(ds.get(j).label))
                     throw new ErrorSyntax(ds.get(j).span(), "The parameter name \"" + ds.get(j).label + "\" cannot appear more than once.");
-        Macro ans = new Macro(p, isPrivate, this, n, ds, v);
-        Macro old = macros.put(n, ans);
+        Macro ans = new Macro(p, isPrivate, this, labelPos, label, ds, v);
+        Macro old = macros.put(label, ans);
         if (old != null) {
-            macros.put(n, old);
-            throw new ErrorSyntax(p, "You cannot declare more than one macro with the same name \"" + n + "\" in the same file.");
+            macros.put(label, old);
+            throw new ErrorSyntax(p, "You cannot declare more than one macro with the same name \"" + label + "\" in the same file.");
         }
     }
 
+    public SafeList<Macro> getAllMacros() {
+        return new SafeList<Macro>(macros.values());
+    }
+
     /** Add a FUN or PRED declaration. */
-    void addFunc(Pos p, Pos isPrivate, String n, Expr f, List<Decl> decls, Expr t, Expr v) throws Err {
+    void addFunc(Pos p, Pos isPrivate, ExprVar n, Expr f, List<Decl> decls, Expr t, Expr v) throws Err {
         if (decls == null)
             decls = new ArrayList<Decl>();
         else
@@ -1610,15 +1644,15 @@ public final class CompModule extends Browsable implements Module {
             }
         }
         status = 3;
-        dup(p, n, false);
+        dup(p, n.label, false);
         ExprHasName dup = Decl.findDuplicateName(decls);
         if (dup != null)
             throw new ErrorSyntax(dup.span(), "The parameter name \"" + dup.label + "\" cannot appear more than once.");
-        Func ans = new Func(p, isPrivate, n, decls, t, v);
-        ArrayList<Func> list = funcs.get(n);
+        Func ans = new Func(p, isPrivate, n.pos, n.label, decls, t, v);
+        ArrayList<Func> list = funcs.get(n.label);
         if (list == null) {
             list = new ArrayList<Func>();
-            funcs.put(n, list);
+            funcs.put(n.label, list);
         }
         list.add(ans);
     }
@@ -1663,7 +1697,7 @@ public final class CompModule extends Browsable implements Module {
                 if (err)
                     continue;
                 try {
-                    f = new Func(f.pos, f.isPrivate, fullname, tmpdecls.makeConst(), ret, f.getBody());
+                    f = new Func(f.pos, f.isPrivate, f.labelPos, fullname, tmpdecls.makeConst(), ret, f.getBody());
                     list.set(listi, f);
                     rep.typecheck("" + f + ", RETURN: " + f.returnDecl.type() + "\n");
                 } catch (Err ex) {
@@ -1727,12 +1761,12 @@ public final class CompModule extends Browsable implements Module {
     // ============================================================================================================================//
 
     /** Add an ASSERT declaration. */
-    String addAssertion(Pos pos, String name, Expr value) throws Err {
+    String addAssertion(Pos pos, Pos labelPos, String name, Expr value) throws Err {
         status = 3;
         if (name == null || name.length() == 0)
             name = "assert$" + (1 + asserts.size());
         dup(pos, name, false);
-        Expr old = asserts.put(name, ExprUnary.Op.NOOP.make(value.span().merge(pos), value));
+        Assert old = asserts.put(name, new Assert(pos.merge(value.span()), labelPos, name, ExprUnary.Op.NOOP.make(value.span(), value)));
         if (old != null) {
             asserts.put(name, old);
             throw new ErrorSyntax(pos, "\"" + name + "\" is already the name of an assertion in this module.");
@@ -1746,11 +1780,12 @@ public final class CompModule extends Browsable implements Module {
      */
     private JoinableList<Err> resolveAssertions(A4Reporter rep, JoinableList<Err> errors, List<ErrorWarning> warns) throws Err {
         Context cx = new Context(this, warns);
-        for (Map.Entry<String,Expr> e : asserts.entrySet()) {
-            Expr expr = e.getValue();
+        for (Map.Entry<String,Assert> e : asserts.entrySet()) {
+            Assert _assert = e.getValue();
+            Expr expr = _assert.expr;
             expr = cx.check(expr).resolve_as_formula(warns);
             if (expr.errors.isEmpty()) {
-                e.setValue(expr);
+                e.setValue(new Assert(_assert.pos, _assert.labelPos, _assert.label, expr));
                 rep.typecheck("Assertion " + e.getKey() + ": " + expr.type() + "\n");
             } else
                 errors = errors.make(expr.errors);
@@ -1762,10 +1797,10 @@ public final class CompModule extends Browsable implements Module {
      * Return an unmodifiable list of all assertions in this module.
      */
     @Override
-    public ConstList<Pair<String,Expr>> getAllAssertions() {
-        TempList<Pair<String,Expr>> ans = new TempList<Pair<String,Expr>>(asserts.size());
-        for (Map.Entry<String,Expr> e : asserts.entrySet()) {
-            ans.add(new Pair<String,Expr>(e.getKey(), e.getValue()));
+    public ConstList<Assert> getAllAssertions() {
+        TempList<Assert> ans = new TempList<Assert>(asserts.size());
+        for (Assert a : asserts.values()) {
+            ans.add(a);
         }
         return ans.makeConst();
     }
@@ -1851,7 +1886,8 @@ public final class CompModule extends Browsable implements Module {
     // ============================================================================================================================//
 
     /** Add a COMMAND declaration. */
-    void addCommand(boolean followUp, Pos pos, ExprVar name, boolean check, int overall, int bitwidth, int seq, int tmn, int tmx, int exp, List<CommandScope> scopes, ExprVar label) throws Err {
+    void addCommand(boolean followUp, Pos pos, ExprVar name, ExprVar commandKeyword, int overall, int bitwidth, int seq, int tmn, int tmx, int exp, List<CommandScope> scopes, ExprVar label) throws Err {
+        boolean check = commandKeyword.label.equals("c");
         if (followUp && !Version.experimental)
             throw new ErrorSyntax(pos, "Syntax error encountering => symbol.");
         if (label != null)
@@ -1863,7 +1899,7 @@ public final class CompModule extends Browsable implements Module {
             throw new ErrorSyntax(pos, "Predicate/assertion name cannot contain \'@\'");
         String labelName = (label == null || label.label.length() == 0) ? name.label : label.label;
         Command parent = followUp ? commands.get(commands.size() - 1) : null;
-        Command newcommand = new Command(pos, name, labelName, check, overall, bitwidth, seq, tmn, tmx, exp, scopes, null, name, parent);
+        Command newcommand = new Command(pos, name, labelName, check, overall, bitwidth, seq, tmn, tmx, exp, scopes, null, commandKeyword, name, parent);
         if (parent != null)
             commands.set(commands.size() - 1, newcommand);
         else
@@ -1871,8 +1907,8 @@ public final class CompModule extends Browsable implements Module {
     }
 
     /** Add a COMMAND declaration. */
-    void addCommand(boolean followUp, Pos pos, Expr e, boolean check, int overall, int bitwidth, int seq, int tmn, int tmx, int expects, List<CommandScope> scopes, ExprVar label) throws Err {
-
+    void addCommand(boolean followUp, Pos pos, Expr e, ExprVar commandKeyword, int overall, int bitwidth, int seq, int tmn, int tmx, int expects, List<CommandScope> scopes, ExprVar label) throws Err {
+        boolean check = commandKeyword.label.equals("c");
         if (followUp && !Version.experimental)
             throw new ErrorSyntax(pos, "Syntax error encountering => symbol.");
 
@@ -1882,12 +1918,12 @@ public final class CompModule extends Browsable implements Module {
         status = 3;
         String n;
         if (check)
-            n = addAssertion(pos, "check$" + (1 + commands.size()), e);
+            n = addAssertion(pos, null, "check$" + (1 + commands.size()), e);
         else
-            addFunc(e.span().merge(pos), Pos.UNKNOWN, n = "run$" + (1 + commands.size()), null, new ArrayList<Decl>(), null, e);
+            addFunc(e.span().merge(pos), Pos.UNKNOWN, ExprVar.make( Pos.UNKNOWN, n = "run$" + (1 + commands.size())), null, new ArrayList<Decl>(), null, e);
         String labelName = (label == null || label.label.length() == 0) ? n : label.label;
         Command parent = followUp ? commands.get(commands.size() - 1) : null;
-        Command newcommand = new Command(e.span().merge(pos), e, labelName, check, overall, bitwidth, seq, tmn, tmx, expects, scopes, null, ExprVar.make(null, n), parent);
+        Command newcommand = new Command(e.span().merge(pos), e, labelName, check, overall, bitwidth, seq, tmn, tmx, expects, scopes, null, commandKeyword, ExprVar.make(null, n), parent);
         if (parent != null)
             commands.set(commands.size() - 1, newcommand);
         else
@@ -1896,8 +1932,9 @@ public final class CompModule extends Browsable implements Module {
 
     public void addDefaultCommand() {
         if (commands.isEmpty()) {
-            addFunc(Pos.UNKNOWN, Pos.UNKNOWN, "$$Default", null, new ArrayList<Decl>(), null, ExprConstant.TRUE);
-            commands.add(new Command(Pos.UNKNOWN, ExprConstant.TRUE, "Default", false, 4, 4, 4, -1, -1, 1, null, null, ExprVar.make(null, "$$Default"), null));
+            addFunc(Pos.UNKNOWN, Pos.UNKNOWN, ExprVar.make(Pos.UNKNOWN, "$$Default"), null, new ArrayList<Decl>(), null, ExprConstant.TRUE);
+            ExprVar check = ExprVar.make(Pos.UNKNOWN, "check");
+            commands.add(new Command(Pos.UNKNOWN, ExprConstant.TRUE, "Default", false, 4, 4, 4, -1, -1, 1, null, null, check, ExprVar.make(null, "$$Default"), null));
         }
     }
 
@@ -1917,7 +1954,14 @@ public final class CompModule extends Browsable implements Module {
             if (m.size() < 1)
                 throw new ErrorSyntax(cmd.pos, "The assertion \"" + cname + "\" cannot be found.");
 
-            Expr expr = (Expr) (m.get(0));
+            Expr expr;
+            if (m.get(0) instanceof Assert){
+                Assert _assert = (Assert) m.get(0);
+                expr = _assert.expr;
+                declaringClause = _assert;
+            }else{
+                expr = (Expr) m.get(0);
+            }
             e = expr.not();
         } else {
             List<Object> m = getRawQS(4, cname); // We prefer fun/pred in the
@@ -1947,13 +1991,13 @@ public final class CompModule extends Browsable implements Module {
                 throw new ErrorSyntax(cmd.pos, "Mutable sig " + et.sig + " is not top-level thus cannot have scopes assigned.");
             if (et.isExact && s.isVariable != null)
                 throw new ErrorSyntax(cmd.pos, "Sig " + et.sig + " is variable thus scope cannot be exact.");
-            sc.add(new CommandScope(null, s, et.isExact, et.startingScope, et.endingScope, et.increment));
+            sc.add(new CommandScope(et.pos, et.sigPos, s, et.isExact, et.startingScope, et.endingScope, et.increment));
         }
 
         if (cmd.nameExpr != null) {
             cmd.nameExpr.setReferenced(declaringClause);
         }
-        return new Command(cmd.pos, cmd.nameExpr, cmd.label, cmd.check, cmd.overall, cmd.bitwidth, cmd.maxseq, cmd.minprefix, cmd.maxprefix, cmd.expects, sc.makeConst(), exactSigs, globalFacts.and(e), parent);
+        return new Command(cmd.pos, cmd.nameExpr, cmd.label, cmd.check, cmd.overall, cmd.bitwidth, cmd.maxseq, cmd.minprefix, cmd.maxprefix, cmd.expects, sc.makeConst(), exactSigs, cmd.commandKeyword, globalFacts.and(e), parent);
 
     }
 
@@ -2024,10 +2068,10 @@ public final class CompModule extends Browsable implements Module {
             cx.put("this", s.decl.get());
             Expr bound = cx.check(d.expr).resolve_as_set(warns);
             cx.remove("this");
-            String[] names = new String[d.names.size()];
-            for (int i = 0; i < names.length; i++)
-                names[i] = d.names.get(i).label;
-            Field[] fields = s.addTrickyField(d.span(), d.isPrivate, d.disjoint, d.disjoint2, null, d.isVar, names, bound);
+            // String[] names = new String[d.names.size()];
+            // for (int i = 0; i < names.length; i++)
+            //     names[i] = d.names.get(i).label;
+            Field[] fields = s.addTrickyField(d.span(), d.isPrivate, d.disjoint, d.disjoint2, null, d.isVar, d.names, bound);
             final VisitQuery<Sig> q = new VisitQuery<Sig>() {
 
                 @Override
@@ -2039,9 +2083,9 @@ public final class CompModule extends Browsable implements Module {
                 }
             };
             Sig qr = q.visitThis(bound);
-            if (d.isVar == null && qr != null)
+            if (d.isVar == null && qr != null) 
                 warns.add(new ErrorWarning(d.span(), "Static field types with variable bound.\n" + "Field " + d.names.get(0) + " is static but " + qr.label + " is variable."));
-            if (d.isVar == null && s.isVariable != null)
+            if (d.isVar == null && s.isVariable != null) 
                 warns.add(new ErrorWarning(d.span(), "Static field inside variable sig.\n" + "Field " + d.names.get(0) + " is static but " + s.label + " is variable."));
             for (Field f : fields) {
                 rep.typecheck("Sig " + s + ", Field " + f.label + ": " + f.type() + "\n");
@@ -2088,7 +2132,7 @@ public final class CompModule extends Browsable implements Module {
         for (CompModule m : root.allModules)
             for (Sig s : new ArrayList<Sig>(m.sigs.values()))
                 if (m != root || (s != root.metaSig && s != root.metaField)) {
-                    PrimSig ka = new PrimSig(s.label + "$", root.metaSig, Attr.ONE, PRIVATE.makenull(s.isPrivate), Attr.META);
+                    PrimSig ka = new PrimSig(Pos.UNKNOWN, s.label + "$", Pos.UNKNOWN, root.metaSig, Attr.ONE, PRIVATE.makenull(s.isPrivate), Attr.META);
                     sig2meta.put(s, ka);
                     ka.addDefinedField(Pos.UNKNOWN, null, Pos.UNKNOWN, "value", s);
                     m.new2old.put(ka, ka);
@@ -2099,7 +2143,7 @@ public final class CompModule extends Browsable implements Module {
                         Pos priv = field.isPrivate;
                         if (priv == null)
                             priv = s.isPrivate;
-                        PrimSig kb = new PrimSig(s.label + "$" + field.label, root.metaField, Attr.ONE, PRIVATE.makenull(priv), Attr.META);
+                        PrimSig kb = new PrimSig(Pos.UNKNOWN, s.label + "$" + field.label, Pos.UNKNOWN, root.metaField, Attr.ONE, PRIVATE.makenull(priv), Attr.META);
                         field2meta.put(field, kb);
                         m.new2old.put(kb, kb);
                         m.sigs.put(base(kb), kb);
@@ -2413,6 +2457,14 @@ public final class CompModule extends Browsable implements Module {
                 d.expr.accept(visitor);
             });
             s.getFacts().forEach(f -> f.accept(visitor));
+
+            if(s instanceof SubsetSig){
+                SubsetSig ss = (SubsetSig) s;
+                ss.parentRefs().forEach( p -> p.accept(visitor));
+            }else{
+                PrimSig ps = (PrimSig) s;
+                ps.parentRef().accept(visitor);
+            }
         });
 
         funcs.values().forEach(funs -> {
@@ -2430,6 +2482,7 @@ public final class CompModule extends Browsable implements Module {
         });
         asserts.values().forEach(assrt -> {
             assrt.accept(visitor);
+            assrt.expr.accept(visitor);
         });
         commands.forEach(cmd -> {
             if (cmd.nameExpr != null)
@@ -2445,12 +2498,80 @@ public final class CompModule extends Browsable implements Module {
             if (open.expressions != null)
                 open.expressions.stream().filter(x -> x != null).forEach(ex -> ex.accept(visitor));
         });
+
+        // macros are not visitable for now ( accept() throws an exception)
         macros.values().forEach(macro -> {
-            macro.accept(visitor);
+           macro.accept(visitor);
         });
         params.values().forEach(x -> x.accept(visitor));
         return null;
     }
+
+    interface Action{ void call();}
+    private void tryIgnore(Action action) {try { action.call();} catch(Exception ex) {}}
+
+    public <T> void visitExpressionsResilient(VisitReturn<T> visitor) {
+        sigs.values().forEach(s -> {
+            s.accept(visitor);
+            s.getFieldDecls().forEach(d -> {
+                d.names.forEach(x -> tryIgnore(() -> x.accept(visitor)));
+                tryIgnore( () -> d.expr.accept(visitor));
+            });
+            s.getFacts().forEach(f -> tryIgnore(() -> f.accept(visitor)));
+
+            if(s instanceof SubsetSig){
+                SubsetSig ss = (SubsetSig) s;
+                ss.parentRefs().forEach( p -> tryIgnore( () -> p.accept(visitor)));
+            }else {
+                PrimSig ps = (PrimSig) s;
+                tryIgnore ( () -> ps.parentRef().accept(visitor));
+            }
+
+        });
+
+        funcs.values().forEach(funs -> {
+            funs.forEach(fun -> {
+
+                //System.out.println("visiting func " + fun.label + ". label pos: " + fun.labelExpr().pos);
+                //tryIgnore ( () -> fun.labelExpr().accept(visitor));
+                fun.accept(visitor);
+                fun.getBody().accept(visitor);
+                fun.decls.forEach(d -> {
+                    tryIgnore( () -> d.expr.accept(visitor));
+                    d.names.forEach(n -> tryIgnore ( () -> n.accept(visitor)));
+                });
+                tryIgnore( () -> fun.returnDecl.accept(visitor));
+            });
+        });
+        facts.forEach(fact -> {
+            tryIgnore ( () -> fact.b.accept(visitor));
+        });
+        asserts.values().forEach(assrt -> {
+            tryIgnore ( () -> assrt.accept(visitor));
+            tryIgnore ( () -> assrt.expr.accept(visitor));
+        });
+        commands.forEach(cmd -> {
+            if (cmd.nameExpr != null)
+                tryIgnore ( () -> cmd.nameExpr.accept(visitor));
+
+            cmd.additionalExactScopes.forEach(sig -> tryIgnore( () -> sig.accept(visitor)));
+            tryIgnore( () -> cmd.formula.accept(visitor));
+            cmd.scope.forEach(scope -> {
+                tryIgnore( () -> scope.sigRef().accept(visitor));
+            });
+        });
+        opens.values().forEach(open -> {
+            if (open.expressions != null)
+                open.expressions.stream().filter(x -> x != null).forEach(ex -> tryIgnore( () -> ex.accept(visitor)));
+        });
+
+        // macros are not visitable for now ( accept() throws an exception)
+        macros.values().forEach(macro -> {
+            tryIgnore( () -> macro.accept(visitor));
+        });
+        params.values().forEach(x -> tryIgnore( () -> x.accept(visitor)));
+    }
+
 
     public Expr find(Pos pos) {
         if (pos == null)
@@ -2463,7 +2584,7 @@ public final class CompModule extends Browsable implements Module {
         }
         Holder holder = new Holder();
 
-        visitExpressions(new VisitQueryOnce<Object>() {
+        visitExpressionsResilient(new VisitQueryOnce<Object>() {
 
             @Override
             public boolean visited(Expr expr) {

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/CompUtil.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/CompUtil.java
@@ -498,4 +498,8 @@ public final class CompUtil {
         module.addDefaultCommand();
         return module;
     }
+
+    public static CompModule nullModule() {
+        return new CompModule(null, "", "");
+    }
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/Macro.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/Macro.java
@@ -30,11 +30,12 @@ import edu.mit.csail.sdg.ast.Expr;
 import edu.mit.csail.sdg.ast.ExprBad;
 import edu.mit.csail.sdg.ast.ExprCustom;
 import edu.mit.csail.sdg.ast.ExprVar;
+import edu.mit.csail.sdg.ast.VisitReturn;
 import edu.mit.csail.sdg.parser.CompModule.Context;
 
 /** Immutable; this class represents a macro. */
 
-final class Macro extends ExprCustom {
+public final class Macro extends ExprCustom {
 
     /** If nonnull, this is a private macro. */
     final Pos                        isPrivate;
@@ -43,7 +44,9 @@ final class Macro extends ExprCustom {
     private final CompModule         realModule;
 
     /** The name of the macro. */
-    private final String             name;
+    public final String             name;
+
+    public final Pos namePos;
 
     /** The list of parameters (can be an empty list) */
     private final ConstList<ExprVar> params;
@@ -52,33 +55,34 @@ final class Macro extends ExprCustom {
      * The list of arguments (can be an empty list) (must be equal or shorter than
      * this.params)
      */
-    private final ConstList<Expr>    args;
+    public final ConstList<Expr>    args;
 
     /** The macro body. */
-    private final Expr               body;
+    public final Expr               body;
 
     /** Construct a new Macro object. */
-    private Macro(Pos pos, Pos isPrivate, CompModule realModule, String name, List<ExprVar> params, List<Expr> args, Expr body) {
+    private Macro(Pos pos, Pos isPrivate, CompModule realModule, Pos namePos, String name, List<ExprVar> params, List<Expr> args, Expr body) {
         super(pos, new ErrorFatal(pos, "Incomplete call on the macro \"" + name + "\""));
         this.realModule = realModule;
         this.isPrivate = isPrivate;
         this.name = name;
+        this.namePos = namePos;
         this.params = ConstList.make(params);
         this.args = ConstList.make(args);
         this.body = body;
     }
 
     /** Construct a new Macro object. */
-    Macro(Pos pos, Pos isPrivate, CompModule realModule, String name, List<ExprVar> params, Expr body) {
-        this(pos, isPrivate, realModule, name, params, null, body);
+    Macro(Pos pos, Pos isPrivate, CompModule realModule, Pos namePos, String name, List<ExprVar> params, Expr body) {
+        this(pos, isPrivate, realModule, namePos, name, params, null, body);
     }
 
     Macro addArg(Expr arg) {
-        return new Macro(pos, isPrivate, realModule, name, params, Util.append(args, arg), body);
+        return new Macro(pos, isPrivate, realModule, namePos, name, params, Util.append(args, arg), body);
     }
 
     Expr changePos(Pos pos) {
-        return new Macro(pos, isPrivate, realModule, name, params, args, body);
+        return new Macro(pos, isPrivate, realModule, namePos, name, params, args, body);
     }
 
     /**
@@ -132,7 +136,16 @@ final class Macro extends ExprCustom {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return name;
+        StringBuilder sb = new StringBuilder();
+        sb.append(name);
+        if (! this.params.isEmpty()){
+            sb.append("[");
+            sb.append( String.join(", ", this.params.stream().map(p -> p.label).toArray(String[]::new)) );
+            sb.append("]");
+        }
+        sb.append(" = ");
+        sb.append(this.body.toString());
+        return sb.toString();
     }
 
     /** {@inheritDoc} */
@@ -148,7 +161,12 @@ final class Macro extends ExprCustom {
     }
 
     public Macro copy() {
-        return new Macro(pos, isPrivate, realModule, name, params, args, body);
+        return new Macro(pos, isPrivate, realModule, namePos, name, params, args, body);
     }
 
+
+    @Override
+    public <T> T accept(VisitReturn<T> visitor) throws Err {
+        return visitor.visit(this);
+    }
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/MarkdownHandler.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/parser/MarkdownHandler.java
@@ -78,7 +78,7 @@ public class MarkdownHandler {
                 while ((line = br.readLine()) != null) {
                     state = state.process(line, yaml, alloy);
                     if (state == null)
-                        return content;
+                        return "";
                 }
             }
             return alloy.toString();

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/sim/SimInstance.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/sim/SimInstance.java
@@ -37,6 +37,7 @@ import edu.mit.csail.sdg.alloy4.ErrorSyntax;
 import edu.mit.csail.sdg.alloy4.ErrorType;
 import edu.mit.csail.sdg.alloy4.Pair;
 import edu.mit.csail.sdg.alloy4.Util;
+import edu.mit.csail.sdg.ast.Assert;
 import edu.mit.csail.sdg.ast.Decl;
 import edu.mit.csail.sdg.ast.Expr;
 import edu.mit.csail.sdg.ast.ExprBinary;
@@ -56,6 +57,7 @@ import edu.mit.csail.sdg.ast.Sig.Field;
 import edu.mit.csail.sdg.ast.Sig.PrimSig;
 import edu.mit.csail.sdg.ast.Sig.SubsetSig;
 import edu.mit.csail.sdg.ast.VisitReturn;
+import edu.mit.csail.sdg.parser.Macro;
 
 /** Mutable; represents an instance. */
 
@@ -910,6 +912,21 @@ public final class SimInstance extends VisitReturn<Object> {
             return (SimTupleset) ans;
         else
             throw new ErrorFatal("Unknown sig " + x + " encountered during evaluation.");
+    }
+
+    @Override
+    public Object visit(Func x) throws Err {
+        return null;
+    }
+
+    @Override
+    public Object visit(Assert x) throws Err {
+        return null;
+    }
+
+    @Override
+    public Object visit(Macro x) throws Err {
+        return null;
     }
 
     /** {@inheritDoc} */

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/translator/A4SolutionReader.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/translator/A4SolutionReader.java
@@ -23,6 +23,7 @@ import static edu.mit.csail.sdg.ast.Sig.UNIV;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -39,6 +40,7 @@ import edu.mit.csail.sdg.alloy4.Util;
 import edu.mit.csail.sdg.alloy4.XMLNode;
 import edu.mit.csail.sdg.ast.Attr;
 import edu.mit.csail.sdg.ast.Expr;
+import edu.mit.csail.sdg.ast.ExprHasName;
 import edu.mit.csail.sdg.ast.ExprVar;
 import edu.mit.csail.sdg.ast.Sig;
 import edu.mit.csail.sdg.ast.Sig.Field;
@@ -217,7 +219,7 @@ public final class A4SolutionReader {
                     break;
                 }
             if (ans == null) {
-                ans = new PrimSig(label, (PrimSig) parent, isAbstract, isLone, isOne, isSome, isPrivate, isMeta, isEnum, isVar);
+                ans = new PrimSig(null, label, Pos.UNKNOWN, (PrimSig) parent, isAbstract, isLone, isOne, isSome, isPrivate, isMeta, isEnum, isVar);
                 allsigs.add(ans);
             }
         } else {
@@ -228,7 +230,7 @@ public final class A4SolutionReader {
                     break;
                 }
             if (ans == null) {
-                ans = new SubsetSig(label, parents, isExact, isLone, isOne, isSome, isPrivate, isMeta, isVar);
+                ans = new SubsetSig(null, label, null, parents, isExact, isLone, isOne, isSome, isPrivate, isMeta, isVar);
                 allsigs.add(ans);
             }
         }
@@ -302,10 +304,11 @@ public final class A4SolutionReader {
                 choices.remove(f);
                 break;
             }
-        if (field == null)
-            field = parent.addTrickyField(Pos.UNKNOWN, isPrivate, null, null, isMeta, isVar, new String[] {
-                                                                                                           label
-            }, UNIV.join(type))[0];
+        if (field == null){
+            ExprHasName labelExpr = ExprVar.make(null, label);
+            field = parent.addTrickyField(Pos.UNKNOWN, isPrivate, null, null, isMeta, isVar, Arrays.asList(labelExpr)
+            , UNIV.join(type))[0];
+        }
         TupleSet ts = parseTuples(node, arity);
         expr2ts.put(field, ts);
         return field;

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/translator/ConvToConjunction.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/translator/ConvToConjunction.java
@@ -17,6 +17,7 @@ package edu.mit.csail.sdg.translator;
 
 import edu.mit.csail.sdg.alloy4.Err;
 import edu.mit.csail.sdg.alloy4.Pos;
+import edu.mit.csail.sdg.ast.Assert;
 import edu.mit.csail.sdg.ast.Expr;
 import edu.mit.csail.sdg.ast.ExprBinary;
 import edu.mit.csail.sdg.ast.ExprCall;
@@ -27,9 +28,11 @@ import edu.mit.csail.sdg.ast.ExprList;
 import edu.mit.csail.sdg.ast.ExprQt;
 import edu.mit.csail.sdg.ast.ExprUnary;
 import edu.mit.csail.sdg.ast.ExprVar;
+import edu.mit.csail.sdg.ast.Func;
 import edu.mit.csail.sdg.ast.Sig;
 import edu.mit.csail.sdg.ast.Sig.Field;
 import edu.mit.csail.sdg.ast.VisitReturn;
+import edu.mit.csail.sdg.parser.Macro;
 
 /**
  * Immutable; this class rearranges the AST to promote as many clauses up to the
@@ -119,6 +122,21 @@ final class ConvToConjunction extends VisitReturn<Expr> {
     /** {@inheritDoc} */
     @Override
     public Expr visit(Sig x) {
+        return x;
+    }
+
+    @Override
+    public Expr visit(Func x) throws Err {
+        return x;
+    }
+
+    @Override
+    public Expr visit(Assert x) throws Err {
+        return x;
+    }
+
+    @Override
+    public Expr visit(Macro x) throws Err {
         return x;
     }
 

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/translator/TranslateAlloyToKodkod.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/translator/TranslateAlloyToKodkod.java
@@ -36,6 +36,7 @@ import edu.mit.csail.sdg.alloy4.ErrorType;
 import edu.mit.csail.sdg.alloy4.Pair;
 import edu.mit.csail.sdg.alloy4.Pos;
 import edu.mit.csail.sdg.alloy4.Util;
+import edu.mit.csail.sdg.ast.Assert;
 import edu.mit.csail.sdg.ast.Command;
 import edu.mit.csail.sdg.ast.CommandScope;
 import edu.mit.csail.sdg.ast.Decl;
@@ -55,6 +56,7 @@ import edu.mit.csail.sdg.ast.Sig;
 import edu.mit.csail.sdg.ast.Sig.Field;
 import edu.mit.csail.sdg.ast.Type;
 import edu.mit.csail.sdg.ast.VisitReturn;
+import edu.mit.csail.sdg.parser.Macro;
 import kodkod.ast.BinaryExpression;
 import kodkod.ast.Decls;
 import kodkod.ast.ExprToIntCast;
@@ -821,7 +823,7 @@ public final class TranslateAlloyToKodkod extends VisitReturn<Object> {
             case EMPTYNESS :
                 return Expression.NONE;
             case IDEN :
-                return Expression.IDEN.intersection(a2k(UNIV).product(Expression.UNIV));
+                return Expression.IDEN.intersection(a2k(UNIV).product(Expression.UNIV)); //this makes bad decompositions, makes static expressions variable
             case STRING :
                 Expression ans = s2k(x.string);
                 if (ans == null)
@@ -890,7 +892,7 @@ public final class TranslateAlloyToKodkod extends VisitReturn<Object> {
             case CAST2INT :
                 return sum(cset(x.sub));
             case RCLOSURE :
-                Expression iden = Expression.IDEN.intersection(a2k(UNIV).product(Expression.UNIV));
+                Expression iden = Expression.IDEN.intersection(a2k(UNIV).product(Expression.UNIV)); //this makes bad decompositions, makes static expressions variable
                 return cset(x.sub).closure().union(iden);
             case CLOSURE :
                 return cset(x.sub).closure();
@@ -948,6 +950,21 @@ public final class TranslateAlloyToKodkod extends VisitReturn<Object> {
         if (ans == null)
             throw new ErrorFatal(x.pos, "Sig \"" + x + "\" is not bound to a legal value during translation.\n");
         return ans;
+    }
+
+    @Override
+    public Object visit(Func x) throws Err {
+        return null;
+    }
+
+    @Override
+    public Object visit(Assert x) throws Err {
+        return null;
+    }
+
+    @Override
+    public Object visit(Macro x) throws Err {
+        return null;
     }
 
     /* ============================= */

--- a/org.alloytools.alloy.core/src/test/java/org/alloytools/alloy/core/AlloyModelsTest.java
+++ b/org.alloytools.alloy.core/src/test/java/org/alloytools/alloy/core/AlloyModelsTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import edu.mit.csail.sdg.alloy4.A4Reporter;
 import edu.mit.csail.sdg.ast.Command;
 import edu.mit.csail.sdg.ast.Module;
+import edu.mit.csail.sdg.ast.VisitQuery;
+import edu.mit.csail.sdg.ast.VisitReturn;
 import edu.mit.csail.sdg.parser.CompModule;
 import edu.mit.csail.sdg.parser.CompUtil;
 import edu.mit.csail.sdg.translator.A4Options;
@@ -48,4 +50,40 @@ public class AlloyModelsTest {
             return;
         }
     }
+
+
+    @Test
+    public void minimalAlloyDoc2() throws Exception {
+        CompModule world = CompUtil.parseEverything_fromString(A4Reporter.NOP,
+         //" \n" +
+         "let nx[foo] { foo.next }\n" +
+         "sig Foo  { next: Foo} \n" +
+         "check TT{ some foo : Foo | some foo.next }\n");
+
+
+
+        VisitReturn<String> visitor = new VisitQuery<String>() {};
+        world.getAllSigs().forEach(sig -> sig.accept(visitor));
+        //world.getAllMacros().forEach(macro -> {macro.toString();});
+        //world.getAllMacros().forEach(macro -> macro.accept(visitor));
+        world.getAllCommands().forEach(cmd -> {
+            System.out.println("nameExpr:" + cmd.nameExpr.toString());
+            System.out.println("formula: " + cmd.formula.toString());
+            System.out.println("label: " + cmd.label);
+//            if (cmd.nameExpr != null)
+//                cmd.nameExpr.accept(visitor);
+
+            //cmd.additionalExactScopes.forEach(sig -> sig.accept(visitor));
+            cmd.formula.accept(visitor);
+//            cmd.scope.forEach(scope -> {
+//                scope.sig.accept(visitor);
+//            });
+
+        });
+        //world.visitExpressions(new VisitQuery<String>() {});
+
+        //Expr expr = world.find(new Pos(null, 12, 3, 15, 3));
+
+    }
+
 }

--- a/org.alloytools.alloy.dist/bnd.bnd
+++ b/org.alloytools.alloy.dist/bnd.bnd
@@ -16,4 +16,9 @@ Main-Class: edu.mit.csail.sdg.alloy4whole.Alloy
 	@${repo;org.sat4j.core}, \
 	@${repo;org.sat4j.maxsat}, \
 	@${repo;org.sat4j.pb}, \
+	@${repo;org.eclipse.lsp4j}, \
+	@${repo;org.eclipse.lsp4j.jsonrpc}, \
+	@${repo;com.google.gson}, \
+	@${repo;org.eclipse.equinox.common}, \
+	@${repo;org.apache.commons.io}, \
 	LICENSES


### PR DESCRIPTION
This PR adds LSP implementation to Alloy, as used by the [vscode extension](https://marketplace.visualstudio.com/items?itemName=ArashSahebolamri.alloy).

The bulk of the LSP implementation lives in `org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageServer.java`.

A few AST-related files are modified as needed to support various LSP features.