### PR TITLE
Feature/line numbers, Issue #79

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/PreferencesDialog.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/PreferencesDialog.java
@@ -10,6 +10,7 @@ import static edu.mit.csail.sdg.alloy4.A4Preferences.FontSize;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.ImplicitThis;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.InferPartialInstance;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.LAF;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.LineNumbers;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.NoOverflow;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.RecordKodkod;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.SkolemDepth;
@@ -420,6 +421,7 @@ public class PreferencesDialog extends JFrame {
         JPanel p = OurUtil.makeGrid(2, gbc().make(), mkCombo(FontName), mkCombo(FontSize), mkCombo(TabSize));
         addToGrid(p, mkCheckBox(SyntaxDisabled), gbc().pos(0, 3).gridwidth(2));
         addToGrid(p, mkCheckBox(AntiAlias), gbc().pos(0, 4).gridwidth(2));
+        addToGrid(p, mkCheckBox(LineNumbers), gbc().pos(0, 5).gridwidth(2));
 
         // JPanel p = new JPanel(new GridBagLayout());
         // addToGrid(p, mkCheckBox(SyntaxDisabled), gbc().pos(0,

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
@@ -29,6 +29,7 @@ import static edu.mit.csail.sdg.alloy4.A4Preferences.FontSize;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.ImplicitThis;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.InferPartialInstance;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.LAF;
+import static edu.mit.csail.sdg.alloy4.A4Preferences.LineNumbers;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.Model0;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.Model1;
 import static edu.mit.csail.sdg.alloy4.A4Preferences.Model2;
@@ -1440,6 +1441,7 @@ public final class SimpleGUI implements ComponentListener, Listener {
             else
                 addToMenu(optmenu, AntiAlias);
             addToMenu(optmenu, A4Preferences.LAF);
+            addToMenu(optmenu, LineNumbers);
 
             optmenu.addSeparator();
 
@@ -1490,6 +1492,14 @@ public final class SimpleGUI implements ComponentListener, Listener {
         status.setFont(new Font(f, Font.PLAIN, n));
         log.setFontSize(n);
         viz.doSetFontSize(n);
+        return null;
+    }
+
+    private Runner doOptRefreshLineNumbers() {
+        if ( wrap ) {
+            return wrapMe();
+        }
+        text.enableLineNumbers(LineNumbers.get());
         return null;
     }
 
@@ -2220,7 +2230,7 @@ public final class SimpleGUI implements ComponentListener, Listener {
         PreferencesDialog.logOnChange(log, A4Preferences.allUserPrefs().toArray(new Pref< ? >[0]));
 
         // Create the text area
-        text = new OurTabbedSyntaxWidget(fontName, fontSize, TabSize.get(), frame);
+        text = new OurTabbedSyntaxWidget(fontName, fontSize, TabSize.get(), LineNumbers.get(), frame);
         text.listeners.add(this);
         text.enableSyntax(!SyntaxDisabled.get());
 
@@ -2282,6 +2292,7 @@ public final class SimpleGUI implements ComponentListener, Listener {
             prefDialog.addChangeListener(wrapToChangeListener(doOptAntiAlias()), AntiAlias);
             prefDialog.addChangeListener(wrapToChangeListener(doOptSyntaxHighlighting()), SyntaxDisabled);
             prefDialog.addChangeListener(wrapToChangeListener(doLookAndFeel()), LAF);
+            prefDialog.addChangeListener(wrapToChangeListener(doOptRefreshLineNumbers()), LineNumbers);
         } finally {
             wrap = false;
         }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/A4Preferences.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/A4Preferences.java
@@ -572,6 +572,9 @@ public class A4Preferences {
     /** The latest tab distance of the Alloy Analyzer. */
     public static final IntChoicePref         TabSize                = IntChoicePref.range("TabSize", "Tab size", 1, 1, 16, 4);
 
+    /** The latest line-number mode selection of the Alloy Analyzer. */
+    public static final BooleanPref           LineNumbers            = new BooleanPref("Line-numbers", "Show line numbers in editors");
+
     /** The latest welcome screen that the user has seen. */
     public static final BooleanPref           Welcome                = new BooleanPref("Welcome", "Show welcome message at start up");
 

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurLineNumberWidget.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurLineNumberWidget.java
@@ -1,0 +1,277 @@
+package edu.mit.csail.sdg.alloy4;
+
+import javax.swing.*;
+import javax.swing.event.CaretEvent;
+import javax.swing.event.CaretListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Element;
+import javax.swing.text.Utilities;
+import java.awt.*;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.awt.font.FontRenderContext;
+import java.util.Collections;
+import java.util.Objects;
+
+public class OurLineNumberWidget extends JComponent implements DocumentListener, CaretListener, ComponentListener {
+
+    /**
+     * combine the two submitted objects with a new OurLineNumberWidget and return
+     * that widget.  We assume that other code has already connected these components appropriately.
+     *
+     * While callers could send any fontName and size that they wanted, here in Allow in the context of
+     * the editor the assumption is that the font preference set by the user for the whole app is
+     * applying here as well, so OurSyntaxWidget will be sending the same font that it receives to use.
+     *
+     * @param textPane the text pane that has the lines we want to draw numbers for
+     * @param scrollPane the scroll pane we will set a header row for to draw the line numbers for textPane
+     * @param display line numbers should display if true, should not otherwise
+     * @param fontName the fontName to be used to draw line numbers.
+     * @return the OurLineNumberWidget linking  the two components, with the display and font set.
+     */
+    public static OurLineNumberWidget build(JTextPane textPane, JScrollPane scrollPane, boolean display, String fontName, int fontSize) {
+        Objects.requireNonNull(textPane);
+        Objects.requireNonNull(textPane.getDocument());
+        Objects.requireNonNull(scrollPane);
+        Objects.requireNonNull(fontName);
+        if ( fontSize < 1 ) {
+            throw new IllegalArgumentException("Font size must be at least 1");
+        }
+
+        OurLineNumberWidget ourLineNumberWidget = new OurLineNumberWidget(textPane, display, fontName, fontSize);
+        scrollPane.setRowHeaderView(ourLineNumberWidget);
+        return ourLineNumberWidget;
+    }
+
+    private static final boolean antiAlias = Util.onMac() || Util.onWindows();
+
+    private final JTextPane textPane;
+    private boolean display;
+    private String fontName;
+    private int fontSize;
+    private int width = 0;
+    private Font font;
+    /** assume we start showing 1 digit. */
+    private int currentMaxDigits = 1;
+    private int descentAdjust;
+
+    OurLineNumberWidget(JTextPane textPane, boolean display, String fontName, int fontSize) {
+        this.textPane = textPane;
+        this.display = display;
+        this.fontName = fontName;
+        this.fontSize = fontSize;
+
+        // falls back to 'Dialog' on not being able to find.
+        this.font = new Font(this.fontName, Font.PLAIN, this.fontSize);
+        this.descentAdjust = makeDescentAdjust();
+
+        textPane.getDocument().addDocumentListener(this);
+        textPane.addComponentListener(this);
+        textPane.addCaretListener(this);
+
+        update();
+    }
+
+    /** use current font to decide a width for the line-number view itself,
+     * based on how many digits are submitted.
+     * @param numberOfDigits
+     * @return
+     */
+    private int calculateWidthForDigits(int numberOfDigits) {
+        if ( display ) {
+            String numberOfDigitsLong = String.join("", Collections.nCopies(numberOfDigits, "0"));
+            return (int)Math.ceil(
+                    font.getStringBounds(numberOfDigitsLong, new FontRenderContext(null, false, false)).getWidth() * 1.2);
+        } else {
+            return 0;
+        }
+    }
+
+    /** capture the descent of the current font, used to adjust (negative y) where the
+     * line number is drawn.  Only needs to change when the font changes.
+     * @return
+     */
+    private int makeDescentAdjust() {
+        return getFontMetrics(font).getDescent();
+    }
+
+    @Override
+    protected void paintComponent(final Graphics g) {
+
+        if ( ! display ) { return; }
+
+        if ( g instanceof Graphics2D && antiAlias ) {
+            ((Graphics2D)g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        }
+
+        super.paintComponent(g);
+        // antiAlias at some point
+
+        Rectangle bounds = g.getClipBounds();
+        final int startDocumentLocation = textPane.viewToModel(new Point(0, bounds.y));
+        final int endDocumentLocation = textPane.viewToModel(new Point(0, bounds.y + bounds.height));
+
+        int docLoc = startDocumentLocation;
+        int maxDigits = 0;
+
+        while ( docLoc <= endDocumentLocation ) {
+            try {
+                Element rootElement = textPane.getDocument().getDefaultRootElement();
+                final int lineIndex = rootElement.getElementIndex(docLoc);
+                final Element line = rootElement.getElement(lineIndex);
+                if (line.getStartOffset() == docLoc) {
+                    int x = niceX();
+                    int y = niceY(docLoc);
+
+                    String formattedLineNumber = formatLineNumberFromIndex(lineIndex);
+                    if ( formattedLineNumber.length() > maxDigits ) {
+                        maxDigits = formattedLineNumber.length();
+                    }
+
+                    g.setColor(Color.BLACK);
+                    if (ifCaretOnSameLine(docLoc, rootElement)) {
+                        Rectangle currentLineViewRec = textPane.modelToView(docLoc);
+                        g.fillRect(0, currentLineViewRec.y, width, currentLineViewRec.height-1 );
+                        g.setColor(Color.YELLOW);
+                    }
+                    g.setFont(font);
+                    g.drawString(formattedLineNumber, x, y);
+                }
+                docLoc = Utilities.getRowEnd(textPane, docLoc) + 1;
+            } catch (BadLocationException e) {
+                // what is the right thing to do here?
+            }
+        }
+        if ( maxDigits != currentMaxDigits ) {
+            currentMaxDigits = maxDigits;
+            update();
+        }
+    }
+
+    private boolean ifCaretOnSameLine(int docLoc, Element rootElement) {
+        return rootElement.getElementIndex(docLoc) == rootElement.getElementIndex(textPane.getCaretPosition());
+    }
+
+    /** a judgement about where in the x direction is good
+     * to start drawing the line number.
+     * @return
+     */
+    private int niceX() {
+        return getInsets().left + 3;
+    }
+
+    /** a judgement about where in the y direction is good
+     * to start drawing the line number for the given document location.
+     * @param docLoc
+     * @return
+     * @throws BadLocationException
+     */
+    private int niceY(int docLoc) throws BadLocationException {
+        Rectangle viewRec = textPane.modelToView(docLoc);
+        return viewRec.y + viewRec.height - descentAdjust;
+    }
+
+    private String formatLineNumberFromIndex(int lineIndex) {
+        return String.format("%d", (lineIndex + 1));
+    }
+
+    /** Make a new width value, set new current preferred size and size,
+     * and try to get this component repainted.
+     * Currently all listener events incur this, which might be more
+     * than strictly needed.
+     */
+    private void update() {
+        width = calculateWidthForDigits(currentMaxDigits);
+        Dimension size = new Dimension(width, textPane.getHeight());
+        setPreferredSize(size);
+        setSize(size);
+        SwingUtilities.invokeLater(this::repaint);
+    }
+
+    // component listener events
+    @Override
+    public void componentResized(ComponentEvent e) {
+        update();
+    }
+
+    @Override
+    public void componentMoved(ComponentEvent e) {
+        update();
+    }
+
+    @Override
+    public void componentShown(ComponentEvent e) {
+        update();
+    }
+
+    @Override
+    public void componentHidden(ComponentEvent e) {
+        update();
+    }
+
+    // caret listener events
+    @Override
+    public void caretUpdate(CaretEvent e) {
+        update();
+    }
+
+    // document listener events
+    @Override
+    public void insertUpdate(DocumentEvent e) {
+        update();
+    }
+
+    @Override
+    public void removeUpdate(DocumentEvent e) {
+        update();
+    }
+
+    @Override
+    public void changedUpdate(DocumentEvent e) {
+        update();
+    }
+
+    /**
+     * Set whether this widget should display or not display line numbers,
+     * incur an update() call if there is a change.
+     * @param flag
+     */
+    public void setDisplay(boolean flag) {
+        boolean oldDisplay = display;
+        this.display = flag;
+        if ( this.display != oldDisplay ) {
+            update();
+        }
+    }
+
+    /**
+     * Set the fontName and fontSize for this widget.  If the
+     * submitted name and size amount to a change of the font itself,
+     * incure an update() call.
+     * @param fontName
+     * @param fontSize
+     */
+    public void updateFontNameAndSize(String fontName, int fontSize) {
+        if ( fontSize < 1 ) {
+            if ( fontName == null || fontName.isEmpty() ) {
+                fontName = Font.MONOSPACED;
+            }
+            fontSize = 14;
+        }
+        String oldFontName = this.fontName;
+        int oldFontSize = this.fontSize;
+
+        this.fontName = fontName;
+        this.fontSize = fontSize;
+
+        if ( !this.fontName.equals(oldFontName) || this.fontSize != oldFontSize ) {
+            font = new Font(this.fontName, Font.PLAIN, this.fontSize);
+            descentAdjust = makeDescentAdjust();
+            update();
+        }
+    }
+
+
+}

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
@@ -124,7 +124,7 @@ public final class OurSyntaxWidget {
      * Constructs a syntax-highlighting widget.
      */
     public OurSyntaxWidget(OurTabbedSyntaxWidget parent) {
-        this(parent, true, "", "Monospaced", 14, 4, null, null);
+        this(parent, true, "", "Monospaced", 14, 4, false, null, null);
     }
 
     /**
@@ -133,7 +133,7 @@ public final class OurSyntaxWidget {
      * @param parent
      */
     @SuppressWarnings("serial" )
-    public OurSyntaxWidget(OurTabbedSyntaxWidget parent, boolean enableSyntax, String text, String fontName, int fontSize, int tabSize, JComponent obj1, JComponent obj2) {
+    public OurSyntaxWidget(OurTabbedSyntaxWidget parent, boolean enableSyntax, String text, String fontName, int fontSize, int tabSize, boolean lineNumbers, JComponent obj1, JComponent obj2) {
         pane.addKeyListener(new KeyListener() {
 
             @Override
@@ -327,6 +327,9 @@ public final class OurSyntaxWidget {
         component.setFocusable(false);
         component.setMinimumSize(new Dimension(50, 50));
         component.setViewportView(pane);
+
+        // do our new thing here for line number display.
+
         modified = false;
     }
 
@@ -573,6 +576,10 @@ public final class OurSyntaxWidget {
     void enableSyntax(boolean flag) {
         if (doc != null)
             doc.do_enableSyntax(flag);
+    }
+
+    void enableLineNumbers(boolean flag) {
+        // something
     }
 
     /**
@@ -865,4 +872,6 @@ public final class OurSyntaxWidget {
         }
         return null;
     }
+
+
 }

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurSyntaxWidget.java
@@ -120,6 +120,8 @@ public final class OurSyntaxWidget {
 
     private volatile CompModule             module;
 
+    private OurLineNumberWidget             ourLineNumberWidget;
+
     /**
      * Constructs a syntax-highlighting widget.
      */
@@ -328,7 +330,7 @@ public final class OurSyntaxWidget {
         component.setMinimumSize(new Dimension(50, 50));
         component.setViewportView(pane);
 
-        // do our new thing here for line number display.
+        ourLineNumberWidget = OurLineNumberWidget.build(pane, component, lineNumbers, fontName, fontSize);
 
         modified = false;
     }
@@ -568,8 +570,10 @@ public final class OurSyntaxWidget {
      * Changes the font name, font size, and tab size for the document.
      */
     void setFont(String fontName, int fontSize, int tabSize) {
-        if (doc != null)
+        if (doc != null) {
             doc.do_setFont(fontName, fontSize, tabSize);
+            ourLineNumberWidget.updateFontNameAndSize(fontName, fontSize);
+        }
     }
 
     /** Enables or disables syntax highlighting. */
@@ -579,7 +583,7 @@ public final class OurSyntaxWidget {
     }
 
     void enableLineNumbers(boolean flag) {
-        // something
+        ourLineNumberWidget.setDisplay(flag);
     }
 
     /**

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurTabbedSyntaxWidget.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurTabbedSyntaxWidget.java
@@ -85,6 +85,11 @@ public final class OurTabbedSyntaxWidget {
      */
     private boolean                     syntaxHighlighting;
 
+    /**
+     * Whether line numbers are currently enable to displayr or not.
+     */
+    private boolean                     lineNumbers;
+
     /** The list of clickable tabs. */
     private final JPanel                tabBar;
 
@@ -157,7 +162,7 @@ public final class OurTabbedSyntaxWidget {
     private final JFrame                parent;
 
     /** Constructs a tabbed editor pane. */
-    public OurTabbedSyntaxWidget(String fontName, int fontSize, int tabSize, JFrame parent) {
+    public OurTabbedSyntaxWidget(String fontName, int fontSize, int tabSize, boolean lineNumbers, JFrame parent) {
         this.parent = parent;
         component.setBorder(null);
         component.setLayout(new BorderLayout());
@@ -174,6 +179,7 @@ public final class OurTabbedSyntaxWidget {
         tabBarScroller.setFocusable(false);
         tabBarScroller.setBorder(null);
         setFont(fontName, fontSize, tabSize);
+        this.lineNumbers = lineNumbers;
         newtab(null);
         tabBarScroller.addComponentListener(new ComponentListener() {
 
@@ -377,9 +383,18 @@ public final class OurTabbedSyntaxWidget {
             t.enableSyntax(flag);
     }
 
+    public void enableLineNumbers(boolean flag) {
+        lineNumbers = flag;
+        for ( OurSyntaxWidget t : tabs) {
+            t.enableLineNumbers(flag);
+        }
+    }
+
     /** Returns the JTextArea of the current text buffer. */
     public OurSyntaxWidget get() {
-        return (me >= 0 && me < tabs.size()) ? tabs.get(me) : new OurSyntaxWidget(this);
+        return (me >= 0 && me < tabs.size()) ? tabs.get(me) :
+                new OurSyntaxWidget(this,
+                    syntaxHighlighting, "", fontName, fontSize, tabSize, lineNumbers, null, null);
     }
 
     /**
@@ -438,7 +453,7 @@ public final class OurTabbedSyntaxWidget {
         JPanel pan = Util.onMac() ? OurUtil.makeVL(null, 2, OurUtil.makeHB(h1, lb, h2)) : OurUtil.makeVL(null, 2, OurUtil.makeHB(h1, lb, h2, GRAY), GRAY);
         pan.setAlignmentX(0.0f);
         pan.setAlignmentY(1.0f);
-        OurSyntaxWidget text = new OurSyntaxWidget(this, syntaxHighlighting, "", fontName, fontSize, tabSize, lb, pan);
+        OurSyntaxWidget text = new OurSyntaxWidget(this, syntaxHighlighting, "", fontName, fontSize, tabSize, lineNumbers, lb, pan);
         tabBar.add(pan, tabs.size());
         tabs.add(text);
         text.listeners.add(listener); // add listener AFTER we've updated


### PR DESCRIPTION
Add line numbers to the editor display, configured with a preference,
issue AlloyTools#79 "Feature Request: Line Numbers."

The OurLineNumberWidget class is added, providing a rowHeader to the
JScrollPane component of OurSyntaxWidget, based on data and events
from the JTextPane pane also of OurSyntaxWidget. OurLineNumberWidget
receives updates to the line-numbers preference, and also to the
font-name and font-size preference, because we draw the line-number
display in the same font as the main document. OurLineNumberWidget
follows the anti-aliasing strategy expressed by the OurAntiAlias
class, by anti-aliasing when we believe we are on a Mac or on
Windows. The view of the line numbers scrolls with the contents of the
text pane.  The line of text where the caret is will have it's line
number in yellow on a black background. The OurLineNumberWidget sets
itself to 0 width, or a calculated width, depending on whether
OurSyntaxWidget constructed or informs it later whether to display.

The code itself does not place a restriction on how many lines there
are in the file or displaying the current line number.  The width of
OurLineNumberWidget grows or shrinks depending on the current number
to display with the most digits.  This author has tested up to seven
digits.

The highlighting of the line of the caret could certainly be changed
if there is need or preference. Size of the line number area, the exact
font used, color and background, these are all on the table.

The preference for displaying line-numbers is in the Alloy
Preferences window, in the Editor tab, at the end of the list of
preferences there. The current value appears in the Options menu
at the end of the third section, in the same section with the
preferences from the Editor tab.

Testing of this feature has involved a Windows 11 machine with Java 8,
and a Macos 11 with Java 8. Testing has involved combinations of:

- launching with the preference unset, or set
- opening previous documents or new documents and entering text
- setting and unsetting the preference
- moving the caret about with arrows, further typing, selections with mouse and keyboard
- adding over 1 million lines to an editor through a lot of pasting, scrolling top to bottom, then removing all the lines
- changing the window size with line numbers on or off

I'd welcome further tests or requests.