### PR TITLE
Fix resource consumption of the alloy visualizer

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4viz/VizGraphPanel.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4viz/VizGraphPanel.java
@@ -18,7 +18,6 @@ package edu.mit.csail.sdg.alloy4viz;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Graphics;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -382,6 +381,7 @@ public final class VizGraphPanel extends JPanel {
                 diagramScrollPanels.get(i).validate();
             }
         }
+        split.setDividerLocation(split.getSize().height - split.getInsets().bottom - split.getDividerSize() - split.getRightComponent().getPreferredSize().height);
     }
 
     /** Changes the font. */
@@ -412,15 +412,6 @@ public final class VizGraphPanel extends JPanel {
      */
     public GraphViewer alloyGetViewer() {
         return viewer.get(0);
-    }
-
-    /**
-     * We override the paint method to auto-resize the divider.
-     */
-    @Override
-    public void paint(Graphics g) {
-        super.paint(g);
-        split.setDividerLocation(split.getSize().height - split.getInsets().bottom - split.getDividerSize() - split.getRightComponent().getPreferredSize().height);
     }
 
     public void resetProjectionAtomCombos() {


### PR DESCRIPTION
Under Ubuntu 20.04 and 22.04, the visualizer caused a high load on Xorg. Setting the divider location from within the paint method seems to have caused an awt graphics feedback loop. Setting the divider location in the remakeAll method seems to have fixed this.

I am not an expert in awt and it might well be that setting the divider location must be set in the paint method for other systems than Linux / Ubuntu. If my fix does not work as expected for those systems, in method `paint` the divider location should only be set if its value would change.

This is related to / should fix issue 40.