### PR TITLE
Fix name of 'org.alloytools.alloy.lsp' project.

### DIFF
--- a/org.alloytools.alloy.lsp/.project
+++ b/org.alloytools.alloy.lsp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.alloytools.alloy.application</name>
+	<name>org.alloytools.alloy.lsp</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
(in 'projectDescription/name' child element of '.project' file).