### PR TITLE
Print the 0th table; label the repeat number

### DIFF
--- a/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
+++ b/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
@@ -181,7 +181,7 @@ public class CLI extends Env {
 				repeat = Integer.MAX_VALUE;
 			}
 			int index = 0;
-			trace.format("%02d. %-5s %-20s %-60s ", n, c.check ? "check" : "run", c.label, c.scope);
+			trace.format("%02d. %-5s %-20s %-60s\n", n, c.check ? "check" : "run", c.label, c.scope);
 			String cname = toCName(c) + "-" + n;
 
 			try {
@@ -198,7 +198,8 @@ public class CLI extends Env {
 				} else {
 					int back = 0;
 					do {
-						trace.back(back).format("%-5d", index);
+						if (repeat > 1)
+							trace.back(back).format("repeat %-5d\n", index);
 						generate(world, solution, options.type(OutputType.table), outdir, cname);
 						index++;
 						back = 5;

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
@@ -178,7 +178,7 @@ public class TableView {
                 Table table = new Table(sigInstances.size() + 1, s.getFields().size() + 1, 1);
                 table.set(0, 0, s.label);
 
-                if (s.getFields().size() == 0 && sigInstances.size() <= 1)
+                if (s.getFields().size() == 0 && sigInstances.size() < 1)
                     continue;
 
                 int c = 1;


### PR DESCRIPTION
The formatting for CLI exec with table output is a bit off, here is an improvement.

Before this change, the repeat-labels are weird and there are some newlines missing. But also the first repeat output doesn't have any instances:
```
$ java -jar org.alloytools.alloy.dist/target/org.alloytools.alloy.dist.jar exec -c example -o -- -t table -r 2 simple.als
00. run   example              []                                                           0    ┌───┬──────┐
│sig│fields│
└───┴──────┘

1    ┌──────────┬──────────┐
│sig       │fields    │
├──────────┼──────────┤
│this/Thing│this/Thing│
│          ├──────────┤
│          │Thing¹    │
│          ├──────────┤
│          │Thing²    │
└──────────┴──────────┘
```

After:
```
$ java -jar org.alloytools.alloy.dist/target/org.alloytools.alloy.dist.jar exec -c example -o -- -t table -r 2 simple.als
00. run   example              []
repeat 0
┌──────────┬──────────┐
│sig       │fields    │
├──────────┼──────────┤
│this/Thing│this/Thing│
│          ├──────────┤
│          │Thing²    │
└──────────┴──────────┘

repeat 1
┌──────────┬──────────┐
│sig       │fields    │
├──────────┼──────────┤
│this/Thing│this/Thing│
│          ├──────────┤
│          │Thing¹    │
│          ├──────────┤
│          │Thing²    │
└──────────┴──────────┘
```

With this change it'll also not print the `repeat 0` when there is only the one.