### PR TITLE
Make the parser match the syntax highlighter [#259]

### DIFF
--- a/org.alloytools.alloy.core/parser/Alloy.cup
+++ b/org.alloytools.alloy.core/parser/Alloy.cup
@@ -297,7 +297,7 @@ parser code {:
         if (content==null && loaded!=null) content = loaded.get(filename);
         if (content==null) content = Util.readAll(filename);
         if (loaded!=null) loaded.put(filename,content);
-        if (content.startsWith("---") || filename.toLowerCase(Locale.ROOT).endsWith(".md")) content = MarkdownHandler.strip(content);
+        if (content.startsWith("---\n") || filename.toLowerCase(Locale.ROOT).endsWith(".md")) content = MarkdownHandler.strip(content);
         content = Util.convertLineBreak(content);
         isr = new StringReader(content);
         CompFilter s = new CompFilter(u, seenDollar, filename, lineOffset, new BufferedReader(isr));


### PR DESCRIPTION
Because both appear to use the Markdown YAML header to indicate that the content is markdown. The issue here was that the highlighter uses the more strict `---\n` whereas the parser was looking for only `---`.

Tested locally and now the syntax highlighter and execution behavior match each other!