### PR TITLE
 Allow not-quite-regular files

### DIFF
--- a/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
+++ b/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
@@ -162,14 +162,15 @@ public class CLI extends Env {
 
 		String filename = options._arguments().remove(0);
 		File file = IO.getFile(filename);
-		if (!file.isFile()) {
-			error("No such file %s", file);
-			return;
-		}
 		if (!file.canRead()) {
 			error("Cannot read file %s", file);
 			return;
 		}
+		if (file.isDirectory()) {
+			error("%s must be a file, not a directory", file);
+			return;
+		}
+
 
 		Map<String, String> cache = new HashMap<>();
 		CompModule world = CompUtil.parseEverything_fromFile(rep, cache, filename);


### PR DESCRIPTION
With this you can do:

  echo 'sig Thing {} run { one Thing }' | alloy exec /dev/stdin

or

  alloy exec <( echo 'sig Thing {} run { one Thing }' )

which allows easier integration into external tools.