### PR TITLE
Disable system exit so that GUI will work again

### DIFF
--- a/org.alloytools.alloy.core/src/main/java/org/alloytools/alloy/core/infra/AlloyDispatcher.java
+++ b/org.alloytools.alloy.core/src/main/java/org/alloytools/alloy/core/infra/AlloyDispatcher.java
@@ -112,7 +112,7 @@ public class AlloyDispatcher extends Env {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        System.exit(exitCode);
+        // System.exit(exitCode);
     }
 
     public void __alloy(BaseOptions options) throws Exception {


### PR DESCRIPTION
When this is active the GUI no longer starts. I think it is because the GUI runs in another thread. I'm not sure where the exit code should be moved to, so I left it in there commented out for now.