### PR TITLE
Fixes file out and show latest

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
@@ -84,6 +84,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.swing.Action;
 import javax.swing.Box;
@@ -202,6 +203,8 @@ import kodkod.engine.satlab.SATFactory;
  *           binaries; added the option to select the decompose strategy
  */
 public final class SimpleGUI implements ComponentListener, Listener {
+
+    final static Pattern TYPED_P = Pattern.compile("([A-Z]{3,6}):");
 
     MacUtil macUtil;
 
@@ -1164,6 +1167,7 @@ public final class SimpleGUI implements ComponentListener, Listener {
      * This method stops the current run or check (how==0 means DONE, how==1 means
      * FAIL, how==2 means STOP).
      */
+
     Runner doStop(Integer how) {
         if (wrap)
             return wrapMe(how);
@@ -1188,8 +1192,9 @@ public final class SimpleGUI implements ComponentListener, Listener {
                 viz.loadXML(f, true, 0);
             else if (subrunningTask == 3)
                 viz.loadXML(f, true);
-            else if (AutoVisualize.get() || subrunningTask == 1)
-                doVisualize("XML: " + f);
+            else if (AutoVisualize.get() || subrunningTask == 1) {
+                doVisualize(f);
+            }
         }
         return null;
     }
@@ -1256,8 +1261,9 @@ public final class SimpleGUI implements ComponentListener, Listener {
             return wrapMe();
         if (latestInstance.length() == 0)
             log.logRed("No previous instances are available for viewing.\n\n");
-        else
-            doVisualize("XML: " + latestInstance);
+        else {
+            doVisualize(latestInstance);
+        }
         return null;
     }
 
@@ -1293,7 +1299,7 @@ public final class SimpleGUI implements ComponentListener, Listener {
                 for (String f : viz.getInstances()) {
                     JMenuItem it = new JMenuItem("Instance: " + viz.getInstanceTitle(f), null);
                     it.setIcon((isViz && f.equals(viz.getXMLfilename())) ? iconYes : iconNo);
-                    it.addActionListener(doVisualize("XML: " + f));
+                    it.addActionListener(doVisualize(f));
                     w.add(it);
                 }
         } finally {
@@ -1639,6 +1645,11 @@ public final class SimpleGUI implements ComponentListener, Listener {
     Runner doVisualize(String arg) {
         if (wrap)
             return wrapMe(arg);
+
+        if (!TYPED_P.matcher(arg).lookingAt()) {
+            arg = "XML: " + arg;
+        }
+
         text.clearShade();
         if (arg.startsWith("MSG: ")) { // MSG: message
             OurDialog.showtext("Detailed Message", arg.substring(5));
@@ -2362,9 +2373,5 @@ public final class SimpleGUI implements ComponentListener, Listener {
                 r.run();
             }
         };
-    }
-
-    private FindReplace getOrderedTab() {
-        return null;
     }
 }

--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleReporter.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleReporter.java
@@ -218,8 +218,10 @@ public final class SimpleReporter extends A4Reporter {
                 results.add(null);
                 span.setLength(len3);
                 span.log("   File written to ");
-                span.logLink(array[1].toString(), "file://" + array[1]);
+                String linkDestination = "CNF: " + array[1];
+                span.logLink(array[1].toString(), linkDestination);
                 span.log("\n\n");
+                gui.doSetLatest(linkDestination);
             }
             if (array[0].equals("debug") && verbosity > 2) {
                 span.log("   " + array[1] + "\n");

--- a/org.alloytools.pardinus.native/src/main/java/org/alloytools/solvers/natv/electrod/ElectrodTransformerRef.java
+++ b/org.alloytools.pardinus.native/src/main/java/org/alloytools/solvers/natv/electrod/ElectrodTransformerRef.java
@@ -48,4 +48,9 @@ public class ElectrodTransformerRef extends ElectrodRef {
         return "transformer";
     }
 
+    @Override
+    public String name() {
+        return "Electrod elo output";
+    }
+
 }


### PR DESCRIPTION
The doVisualize(s) method took a string that had
a type and a parameter, like "XML: /foo/bar..". There was a public method setLatestInstance(s) that sets the parameter part. However, that meant that we could not remember the latest if it wasn't XML. The doVisualize(s) was the central dispatcher for visualization and called from many places.

The doVisualize(s) now takes an _optionally_ typed argument. If it is not typed, we assume XML. So now can we set a typed string via setLatestInstance(s).

When we create an output file as is now supported by the solver architecture, we safe it as "CNF: /...". So when we hit show latest instance, we get the file.

Ugly as hell ...

Fixes #273