### PR TITLE
Fix running the evaluator from the CLI

### DIFF
--- a/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
+++ b/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
@@ -363,7 +363,7 @@ public class CLI extends Env {
 			stdout.flush();
 			Evaluator e = new Evaluator(world, sol, stdin, stdout);
 			String lastCommand = e.loop();
-			if (lastCommand.equals("/exit"))
+			if (lastCommand == null || lastCommand.equals("/exit"))
 				return;
 		}
 	}

--- a/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
+++ b/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
@@ -280,6 +280,7 @@ public class CLI extends Env {
 						trace.format(" expects=%s", c.expects);
 						error("'%s' was satisfied against expectation",c);
 					}
+					trace.format("\n");
 					if (options.evaluator()) {
 						evaluator(world, solution);
 					}

--- a/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
+++ b/org.alloytools.alloy.cli/src/main/java/org/alloytools/alloy/cli/CLI.java
@@ -204,7 +204,6 @@ public class CLI extends Env {
 			}
 		}
 		OutputTrace trace = new OutputTrace(quiet || outdir == null ? null : stderr);
-		Map<CommandInfo, A4Solution> answers = new TreeMap<>();
 		int n = 0;
 
 		int repeat = options.repeat(1);
@@ -281,9 +280,8 @@ public class CLI extends Env {
 						trace.format(" expects=%s", c.expects);
 						error("'%s' was satisfied against expectation",c);
 					}
-
-					if (options.evaluator() && !answers.isEmpty()) {
-						evaluator(world, answers);
+					if (options.evaluator()) {
+						evaluator(world, solution);
 					}
 				}
 				n++;
@@ -358,19 +356,15 @@ public class CLI extends Env {
 			return parts[0];
 	}
 
-	private void evaluator(CompModule world, Map<CommandInfo, A4Solution> answers) throws Exception {
-		for (Entry<CommandInfo, A4Solution> s : answers.entrySet()) {
-			A4Solution sol = s.getValue();
-			if (sol.satisfiable()) {
-				stdout.println("Evaluator for " + s.getKey().command);
-				stdout.flush();
-				Evaluator e = new Evaluator(world, sol, stdin, stdout);
-				String lastCommand = e.loop();
-				if (lastCommand.equals("/exit"))
-					break;
-			}
+	private void evaluator(CompModule world, A4Solution sol) throws Exception {
+		if (sol.satisfiable()) {
+			stdout.println("Evaluator for latest command");
+			stdout.flush();
+			Evaluator e = new Evaluator(world, sol, stdin, stdout);
+			String lastCommand = e.loop();
+			if (lastCommand.equals("/exit"))
+				return;
 		}
-		stdout.println("bye");
 	}
 
 	@Arguments(arg = "path")


### PR DESCRIPTION
It seems the idea here was to populate an `answers` map with satisfiable solutions, then pass that map to the `evaluator` method. However, the `answers` map is never added to, so the check before calling the evaluator always fails.

This PR changes things around a bit so that we just pass the latest solution in to `evaluator` directly, which makes the evaluator run successfully. Not sure whether this matches with @pkriens' intention (probably not) but it worked for me, so I figured I'd put up a PR in case it's useful.

Fixes #307.