### PR TITLE
Link handling was broken

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/SimpleGUI.java
@@ -204,7 +204,7 @@ import kodkod.engine.satlab.SATFactory;
  */
 public final class SimpleGUI implements ComponentListener, Listener {
 
-    final static Pattern TYPED_P = Pattern.compile("([A-Z]{3,6}):");
+    final static Pattern TYPED_P = Pattern.compile("([A-Za-z]{3,6}):");
 
     /**
      * The latest welcome screen; each time we update the welcome screen, we


### PR DESCRIPTION
Fixes #305 

To see the CNF and electrod files it was necessary to handle some files specially. Normally the visualizer gets a semi URN where the scheme indicates the handling. Unfortunately, the https: prefix wasn't recognized and that meant it got the default XML: prefix. 

It now recognizes the https?: prefix and that will open a browser.