### PR TITLE
Removed free() in proof

### DIFF
--- a/org.alloytools.pardinus.native/src/main/java/org/alloytools/solvers/natv/minisatprover/MiniSatProver.java
+++ b/org.alloytools.pardinus.native/src/main/java/org/alloytools/solvers/natv/minisatprover/MiniSatProver.java
@@ -145,10 +145,10 @@ final public class MiniSatProver extends NativeSolver implements SATProver {
             throw new IllegalStateException();
         if (proof == null) {
             final int[][] trace = trace(peer(), true);
-            free();
+
             // if the empty axiom was added to the solver, that axiom will be
             // the last clause in the trace, and it will form its own minimal unsat core.
-            //System.out.println(Arrays.deepToString(trace));
+
             if (trace[trace.length - 1].length == 0) {
                 proof = new LazyTrace(formatTrivial(trace), numberOfClauses());
             } else {


### PR DESCRIPTION
The proof() method threw an exception because the solver was closed half way. The exception was eaten without action and it then ignored the normal proof() handling.

Fixes #311 