### PR TITLE
Make sure the initial font is a monospace font

### DIFF
--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/A4Preferences.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/A4Preferences.java
@@ -14,7 +14,7 @@
  */
 package edu.mit.csail.sdg.alloy4;
 
-import java.awt.GraphicsEnvironment;
+import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -28,6 +28,8 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.DefaultSingleSelectionModel;
 import javax.swing.Icon;
+
+import org.alloytools.graphics.util.AlloyGraphics;
 
 import kodkod.engine.satlab.SATFactory;
 
@@ -569,7 +571,8 @@ public class A4Preferences {
     public static final IntChoicePref         FontSize               = new IntChoicePref("FontSize", "Font size", Arrays.asList(9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32, 36, 40, 44, 48, 54, 60, 66, 72), 14);
 
     /** The latest font name of the Alloy Analyzer. */
-    public static final StringChoicePref      FontName               = new StringChoicePref("FontName", "Font family", Arrays.asList(GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()), "Lucida Grande");
+    public static final StringChoicePref      FontName               = new StringChoicePref("FontName", "Font family", AlloyGraphics.getFontFamilyNames(true), Font.MONOSPACED);
+
 
     /** The latest tab distance of the Alloy Analyzer. */
     public static final IntChoicePref         TabSize                = IntChoicePref.range("TabSize", "Tab size", 1, 1, 16, 4);

--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurCombobox.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/OurCombobox.java
@@ -35,7 +35,10 @@ import javax.swing.border.EmptyBorder;
  * <b>Thread Safety:</b> Can be called only by the AWT event thread.
  */
 
-public class OurCombobox extends JComboBox {
+@SuppressWarnings({
+                   "rawtypes", "unchecked"
+} )
+public class OurCombobox<T> extends JComboBox<T> {
 
     /** This ensures the class can be serialized reliably. */
     private static final long serialVersionUID = 0;
@@ -65,14 +68,15 @@ public class OurCombobox extends JComboBox {
     /**
      * Subclass can override this method to react upon selection change.
      */
-    public void do_changed(Object newValue) {}
+    public void do_changed(Object newValue) {
+    }
 
     /**
      * This helper method makes a copy of the list, and then optionally prepend null
      * at the beginning of the list.
      */
-    private static Vector<Object> do_copy(Object[] list, boolean addNull) {
-        Vector<Object> answer = new Vector<Object>(list.length + (addNull ? 1 : 0));
+    private static <X> Vector<X> do_copy(X[] list, boolean addNull) {
+        Vector<X> answer = new Vector<>(list.length + (addNull ? 1 : 0));
         if (addNull)
             answer.add(null);
         for (int i = 0; i < list.length; i++)
@@ -85,7 +89,7 @@ public class OurCombobox extends JComboBox {
      *
      * @param list - the list of allowed values
      */
-    public OurCombobox(Object[] list) {
+    public OurCombobox(T[] list) {
         this(false, list, 0, 0, null);
     }
 
@@ -102,7 +106,7 @@ public class OurCombobox extends JComboBox {
      * @param initialValue - if nonnull it is the initial value to choose in this
      *            combo box
      */
-    public OurCombobox(boolean addNull, Object[] list, int width, int height, Object initialValue) {
+    public OurCombobox(boolean addNull, T[] list, int width, int height, Object initialValue) {
         super(do_copy(list, addNull));
         setFont(OurUtil.getVizFont());
         setRenderer(new ListCellRenderer() {


### PR DESCRIPTION
This change will filter the fonts by default to be a valid monospace character that can display the normal glyphs. 

Additionally, pimped up the Font selection. The default list shows only a sub selection of mono space fonts but it allows to see all fonts with a checkbox. It also now shows a sample.

![image](https://github.com/user-attachments/assets/102bde29-4be6-4f72-b9c2-70b2a06b5c29)
