### PR TITLE
Fixes #242. Zoompane with theme settings now grows with contents

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4viz/VizCustomizationPanel.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4viz/VizCustomizationPanel.java
@@ -165,7 +165,6 @@ public final class VizCustomizationPanel extends JPanel {
             divider.setDividerLocation(dim.width);
         if (divider != null && divider.getDividerLocation() > dim.width)
             dim.width = divider.getDividerLocation();
-        dim.height = 150;
         zoomPane.setPreferredSize(dim);
         dim.width = 450;
         zoomPane.setMinimumSize(dim);


### PR DESCRIPTION
The theme has a pane with the UI controls to manage the theme settings. This was given a fixed height.

This was changed to use the calculated height.