### PR TITLE
Prepare for next release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,22 @@
 name: release
 
+#
+# This workflow will build Alloy and prepares a release.
+# The private keys for signing and notarizing are kept
+# secret for the project maintainers since it the certiicate
+# is on a personal name. The keys are stored in the
+# envionment secrets 'release'. As an extra safeguard, the
+# password for the p12 key file is passed as an input
+# to the workflow.
+#
+
 on:
-  push:
-    branches: ["release"]
+  workflow_call:
+    inputs:
+      macos_signing_password:
+        description: "Password for p12 key file in 'release' environment secrets"
+        required: true
+        type: string
 
 env:
   LC_ALL: en_US.UTF-8
@@ -13,32 +27,62 @@ jobs:
   build:
     name: build on OpenJDK Linux
     runs-on: ubuntu-latest
+    environment: release
     steps:
+      - name: Mask macos_signing_password
+        run: echo "::add-mask::${{ inputs.macos_signing_password }}"
+        shell: bash
+
       - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
+
       - shell: bash
         run: ./gradlew --parallel release
+
       - if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: '*/target/*reports/tests/'
-      - uses: hydraulic-software/conveyor/actions/build@v14.2
+
+      - name: Prepare macOS signing key and notary key
+        run: |
+          mkdir -p secret/mac
+          echo "${{ secrets.MACOS_SIGNING_KEY }}" | base64 -d > secret/mac/alloy_key_cer.p12
+          echo "${{ secrets.MACOS_NOTARY_KEY }}" > secret/mac/notary_key.p8
+        shell: bash
+
+      - name: Run prepare.sh for Conveyor
+        working-directory: org.alloytools.alloy.dist/conveyor/
+        run: ./prepare.sh
+        shell: bash
+
+      - uses: hydraulic-software/conveyor/actions/build@v18.1
+        env:
+          MACOS_SIGNING_PASSWORD: ${{ inputs.macos_signing_password }}
         with:
-            signing_key: ${{ secrets.CONVEYOR_ROOT_KEY }}
-            command: make site
-            extra_flags: -f org.alloytools.alloy.dist/conveyor/conveyor.conf
-            agree_to_license: 1
+          signing_key: ${{ secrets.CONVEYOR_ROOT_KEY }}
+          command: make site
+          extra_flags: -f org.alloytools.alloy.dist/conveyor/conveyor.conf
+          agree_to_license: 1
+
+      - name: Upload Conveyor output directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: conveyor-output
+          path: output/
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           name: Alloy
-          body: Alloy is an open source language and analyzer for software modeling. It has been used in a wide range of applications, from finding holes in security mechanisms to designing telephone switching networks.
+          body: Alloy is an open source language and analyzer for software modeling. It has been used in a wide range of applications, from finding holes in security mechanisms to designing telephone systems.
           prerelease: false
           draft: true
           files: |
-             output/**
+            output/**

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ gen/
 target/
 enroute.zip
 .metadata
+.github/.project
 *.slo
 *.lo
 *.o

--- a/org.alloytools.alloy.dist/conveyor/.gitignore
+++ b/org.alloytools.alloy.dist/conveyor/.gitignore
@@ -1,1 +1,3 @@
 output/
+secret/
+build/

--- a/org.alloytools.alloy.dist/conveyor/conveyor.conf
+++ b/org.alloytools.alloy.dist/conveyor/conveyor.conf
@@ -13,10 +13,13 @@ app {
   
   vcs-url = "https://github.com/Alloytools/org.alloytools.alloy"
 
-  version= 6.2.0
+  version= 6.3.0
   display-name = "Alloy"
   fsname="alloy" 
   long-fsname="org.alloytools.alloy"
+  compression-level = low
+  vendor = "Alloytools"
+  license = MIT
   
   jvm {
   
@@ -40,14 +43,27 @@ app {
       modules += java.logging
       options += "-Dalloy.fork=true"
   }
-  inputs += ../../org.alloytools.alloy.dist/target/org.alloytools.alloy.dist.jar
+  inputs += build/org.alloytools.alloy.dist.jar
   icons = icons/icon.png
-
-  // For iteration speed. Remove for release.
-  compression-level = low
-  mac.info-plist.LSMinimumSystemVersion = 13.7
-  vendor = "Alloytools"
-  license = MIT
+  
+  linux.amd64.inputs += build/native/linux/amd64/
+  windows.amd64.inputs += build/native/windows/amd64/
+  
+  mac {
+    amd64.inputs += build/native/darwin/amd64/
+    aarch64.inputs += build/native/darwin/arm64/
+    info-plist.LSMinimumSystemVersion = 14
+    // See .github/workflows/release.yml for secrets
+    notarization {
+        issuer-id       = 69a6de93-d779-47e3-e053-5b8c7c11a4d1
+        key-id          = KGRJ25TLB7
+        private-key     = secret/mac/notary_key.p8
+    }
+    signing-key.file = {
+        path = secret/mac/alloy_key_cer.p12
+        password = ${env.MACOS_SIGNING_PASSWORD}
+    }
+  }
 }
 
-conveyor.compatibility-level = 14
+conveyor.compatibility-level = 18

--- a/org.alloytools.alloy.dist/conveyor/prepare.sh
+++ b/org.alloytools.alloy.dist/conveyor/prepare.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Unfortunately, conveyor does not extract binaries from the JAR file
+# and signs them. This script creates a new JAR file with the native directory
+# removed and copies the natives to a separate directory. The conveyor script
+# incldues the appropriate native files in the Resources directory. These
+# will then automatically be signed.
+# For testing purposes, this script also sets the executable bit on the native files.
+#
+# The new JAR file and native directory are placed in the `build` directory.
+# IN = ../target/org.alloytools.alloy.dist.jar
+# OUT = build/org.alloytools.alloy.dist.jar & build/native/
+# 
+
+set -e
+#set -x
+
+if [ "$#" -ne 0 ]; then
+  echo "Usage: $0"
+  exit 1
+fi
+
+IN=$(realpath ../target/org.alloytools.alloy.dist.jar)
+BLD=$(realpath build)
+TMP=$(mktemp -d)
+SN=`basename $IN`
+OUT=$BLD/$SN
+
+rm -rf "$BLD"
+mkdir -p "$BLD/"
+cd "$TMP"
+unzip "$IN"
+mv native "$BLD/"
+rm -rf native
+zip -qr "$OUT" .
+cd -
+rm -rf "$TMP"
+find "$BLD"/native/ -type f -exec chmod a+x {} \; 
+echo "Prepared $OUT with native directory at $NAT"

--- a/org.alloytools.pardinus.core/src/main/java/kodkod/solvers/api/NativeCode.java
+++ b/org.alloytools.pardinus.core/src/main/java/kodkod/solvers/api/NativeCode.java
@@ -92,6 +92,19 @@ public class NativeCode {
 			}
 		}
 
+		String resourcePath = System.getProperty("app.dir");
+		if ( resourcePath != null) {
+			logger.debug("processing 'app.dir' {}", resourcePath);
+			File dir = new File(resourcePath);
+			if (dir.isDirectory()) {
+				LIBRARYPATH.add(dir);
+				PATH.add(dir);
+			} else {
+				logger.info("entry {} not a directory, not added to LIBRARYPATH and PATH", dir.getAbsolutePath());
+			}
+		} else
+			logger.info("no 'app.dir' set");
+		
 		try {
 			cache = Files.createTempDirectory("alloy-").toFile();
 			LIBRARYPATH.add(cache);


### PR DESCRIPTION
A serious issue with the current release is that the Mac executable is not properly signed and notarized. Until recently, MacOS still allowed the applications to start after dire warnings. However, they seem to move in the direction to remove it. You can still execute the app. After having tried to open it, you have to go to`System Settings/Privacy & Security`, scroll all the way do to `Security`and then you can allow the app to be opened ... curious what Jobs would've thought of this ...

Anyway, since I am sponsored by ﻿﻿Matthew Di Ferrante, I became Apple developer and now have a signing certificate.

It turned out that binaries in  JARs was not supported by the app build tool conveyor. This is why the NativeCode now also looks in the application install directory. This was a very minor change.

 Since this certificate has my name on it, I needed a few safeguards to make sure it could not be abused.

- Only the 'release' environment has the secrets
  - CONVEYER_SIGNING_KEY
  - MACOS_SIGNING_KEY (p12 file, password protected)
  - MACOS_NOTARY_KEY (private key text file)
- The release.yml workflow is now manually run and takes an input, the password to the p12 file.

