### PR TITLE
Change Gradle task from 'release' to 'build'

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: 17 
           distribution: temurin
       - shell: bash
-        run: ./gradlew --parallel release
+        run: ./gradlew --parallel build
       - if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Maven has significantly changed so no more snapshots to maven