### PR TITLE
Alternate approach to generate SimTupleset used for tabular output

### DIFF
--- a/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
+++ b/org.alloytools.alloy.core/src/main/java/edu/mit/csail/sdg/alloy4/TableView.java
@@ -166,13 +166,10 @@ public class TableView {
             if (s.builtin)
                 continue;
 
-            TupleSet instanceTuples = solution.eval(s, state).debugGetKodkodTupleset();
+            A4TupleSet instanceTuples = solution.eval(s, state);
             if (instanceTuples != null) {
 
-                List<SimTuple> instancesArray = Util.toList(instanceTuples);
-                sortTuple(instancesArray);
-
-                SimTupleset sigInstances = SimTupleset.make(instancesArray);
+                SimTupleset sigInstances = Util.toSimTupleset(instanceTuples);
                 Table table = new Table(sigInstances.size() + 1, s.getFields().size() + 1, 1);
                 table.set(0, 0, s.label);
 


### PR DESCRIPTION
fixes #341

the buggy version was printing out values generated via `A4TupleSet.debugGetKodkodTupleset()`, which did not do the appropriate internal renaming of atom names, nor did it populate atoms in fields in all places that they needed to. Generating values via `Util.toSimTupleset(A4TupleSet)` generated a `TupleSet` value that does the needed internal renaming and populates the tuples correctly.